### PR TITLE
Change source -> .; Since source does not exist in /bin/sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,7 +85,7 @@ RUN mkdir /etc/service/apache2 && \
 	chmod +x /etc/service/apache2/run
 
 # Add the harvesting cronjob (once per day)
-RUN (crontab -l ; echo "0 1 * * * source /var/www/stationlite/venv3/bin/activate && \
+RUN (crontab -l ; echo "0 1 * * * . /var/www/stationlite/venv3/bin/activate && \
      python /var/www/mediatorws/eidangservices/stationlite/harvest/harvest.py \
      sqlite:////var/www/mediatorws/db/stationlite.db") | crontab
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,8 +85,8 @@ RUN mkdir /etc/service/apache2 && \
 	chmod +x /etc/service/apache2/run
 
 # Add the harvesting cronjob (once per day)
-RUN (crontab -l ; echo "0 1 * * * . /var/www/stationlite/venv3/bin/activate && \
-     python /var/www/mediatorws/eidangservices/stationlite/harvest/harvest.py \
+RUN (crontab -l ; echo "0 1 * * * \
+     /var/www/stationlite/venv3/bin/eida-stationlite-harvest \
      sqlite:////var/www/mediatorws/db/stationlite.db") | crontab
 
 RUN mkdir -p /var/www/mediatorws/log && chown www-data:www-data /var/www/mediatorws/log


### PR DESCRIPTION
Minor fix that should help with cron stationlite harvesting inside the Docker container. It was giving:

    /bin/sh: 1: source not found