### PR TITLE
[ENH]: Added keywordparser for request argument validation.

### DIFF
--- a/eidangservices/federator/server/__init__.py
+++ b/eidangservices/federator/server/__init__.py
@@ -39,7 +39,8 @@ from flask import Flask, make_response, g
 from eidangservices import settings
 from eidangservices.federator import __version__
 from eidangservices.utils import httperrors
-from eidangservices.utils.fdsnws import register_parser_errorhandler
+from eidangservices.utils.fdsnws import (register_parser_errorhandler,
+                                         register_keywordparser_errorhandler)
 
 def create_app(config_dict={}, service_version=__version__):
     """
@@ -82,6 +83,7 @@ def create_app(config_dict={}, service_version=__version__):
         register_error(err)
 
     register_parser_errorhandler(service_version=service_version)
+    register_keywordparser_errorhandler(service_version=service_version)
 
     return app
 

--- a/eidangservices/federator/server/routes/dataselect.py
+++ b/eidangservices/federator/server/routes/dataselect.py
@@ -65,7 +65,7 @@ class DataselectResource(Resource):
         locations=('query',)
     )
     @with_strict_args(
-        (DataselectSchema(), StreamEpochSchema()),
+        (DataselectSchema, StreamEpochSchema),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -92,7 +92,7 @@ class DataselectResource(Resource):
         locations=('form',)
     )
     @with_strict_args(
-        (DataselectSchema(), StreamEpochSchema()),
+        DataselectSchema,
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/federator/server/routes/dataselect.py
+++ b/eidangservices/federator/server/routes/dataselect.py
@@ -44,7 +44,9 @@ from eidangservices.federator import __version__
 from eidangservices.federator.server.schema import DataselectSchema
 from eidangservices.federator.server.process import RequestProcessor
 from eidangservices.utils import fdsnws
-from eidangservices.utils.schema import ManyStreamEpochSchema
+from eidangservices.utils.strict import with_strict_args
+from eidangservices.utils.schema import (ManyStreamEpochSchema,
+                                         StreamEpochSchema)
 
 
 class DataselectResource(Resource):
@@ -60,6 +62,10 @@ class DataselectResource(Resource):
     @use_args(DataselectSchema(), locations=('query',))
     @fdsnws.use_fdsnws_kwargs(
         ManyStreamEpochSchema(context={'request': request}),
+        locations=('query',)
+    )
+    @with_strict_args(
+        (DataselectSchema(), StreamEpochSchema()),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -83,6 +89,10 @@ class DataselectResource(Resource):
     @fdsnws.use_fdsnws_args(DataselectSchema(), locations=('form',))
     @fdsnws.use_fdsnws_kwargs(
         ManyStreamEpochSchema(context={'request': request}),
+        locations=('form',)
+    )
+    @with_strict_args(
+        (DataselectSchema(), StreamEpochSchema()),
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/federator/server/routes/station.py
+++ b/eidangservices/federator/server/routes/station.py
@@ -40,7 +40,9 @@ from eidangservices.federator import __version__
 from eidangservices.federator.server.schema import StationSchema
 from eidangservices.federator.server.process import RequestProcessor
 from eidangservices.utils import fdsnws
-from eidangservices.utils.schema import ManyStreamEpochSchema
+from eidangservices.utils.strict import with_strict_args
+from eidangservices.utils.schema import (ManyStreamEpochSchema,
+                                         StreamEpochSchema)
 
 
 class StationResource(Resource):
@@ -54,6 +56,10 @@ class StationResource(Resource):
     @use_args(StationSchema(), locations=('query',))
     @fdsnws.use_fdsnws_kwargs(
         ManyStreamEpochSchema(context={'request': request}),
+        locations=('query',)
+    )
+    @with_strict_args(
+        (StreamEpochSchema(), StationSchema()),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -77,6 +83,10 @@ class StationResource(Resource):
     @fdsnws.use_fdsnws_args(StationSchema(), locations=('form',))
     @fdsnws.use_fdsnws_kwargs(
         ManyStreamEpochSchema(context={'request': request}),
+        locations=('form',)
+    )
+    @with_strict_args(
+        (StreamEpochSchema(), StationSchema()),
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/federator/server/routes/station.py
+++ b/eidangservices/federator/server/routes/station.py
@@ -59,7 +59,7 @@ class StationResource(Resource):
         locations=('query',)
     )
     @with_strict_args(
-        (StreamEpochSchema(), StationSchema()),
+        (StreamEpochSchema, StationSchema),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -86,7 +86,7 @@ class StationResource(Resource):
         locations=('form',)
     )
     @with_strict_args(
-        (StreamEpochSchema(), StationSchema()),
+        StationSchema,
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/federator/server/routes/wfcatalog.py
+++ b/eidangservices/federator/server/routes/wfcatalog.py
@@ -45,7 +45,9 @@ from eidangservices.federator.server.schema import WFCatalogSchema
 from eidangservices.federator.server.process import RequestProcessor
 from eidangservices.utils import fdsnws
 from eidangservices.utils.httperrors import FDSNHTTPError
-from eidangservices.utils.schema import ManyStreamEpochSchema
+from eidangservices.utils.strict import with_strict_args
+from eidangservices.utils.schema import (ManyStreamEpochSchema,
+                                         StreamEpochSchema)
 
 
 class WFCatalogResource(Resource):
@@ -63,6 +65,10 @@ class WFCatalogResource(Resource):
     @use_args(WFCatalogSchema(), locations=('query',))
     @fdsnws.use_fdsnws_kwargs(
         ManyStreamEpochSchema(context={'request': request}),
+        locations=('query',)
+    )
+    @with_strict_args(
+        (StreamEpochSchema(), WFCatalogSchema()),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -96,6 +102,10 @@ class WFCatalogResource(Resource):
     @fdsnws.use_fdsnws_args(WFCatalogSchema(), locations=('form',))
     @fdsnws.use_fdsnws_kwargs(
         ManyStreamEpochSchema(context={'request': request}),
+        locations=('form',)
+    )
+    @with_strict_args(
+        (StreamEpochSchema(), WFCatalogSchema()),
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/federator/server/routes/wfcatalog.py
+++ b/eidangservices/federator/server/routes/wfcatalog.py
@@ -68,7 +68,7 @@ class WFCatalogResource(Resource):
         locations=('query',)
     )
     @with_strict_args(
-        (StreamEpochSchema(), WFCatalogSchema()),
+        (StreamEpochSchema, WFCatalogSchema),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -105,7 +105,7 @@ class WFCatalogResource(Resource):
         locations=('form',)
     )
     @with_strict_args(
-        (StreamEpochSchema(), WFCatalogSchema()),
+        WFCatalogSchema,
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/stationlite/server/__init__.py
+++ b/eidangservices/stationlite/server/__init__.py
@@ -40,7 +40,8 @@ from flask_sqlalchemy import SQLAlchemy
 
 from eidangservices import settings
 from eidangservices.utils import httperrors
-from eidangservices.utils.fdsnws import register_parser_errorhandler
+from eidangservices.utils.fdsnws import (register_parser_errorhandler,
+                                         register_keywordparser_errorhandler)
 from eidangservices.stationlite import __version__
 
 
@@ -83,6 +84,7 @@ def create_app(config_dict, service_version=__version__):
         register_error(err)
 
     register_parser_errorhandler(service_version=service_version)
+    register_keywordparser_errorhandler(service_version=service_version)
 
     db.init_app(app)
 

--- a/eidangservices/stationlite/server/routes/stationlite.py
+++ b/eidangservices/stationlite/server/routes/stationlite.py
@@ -72,7 +72,7 @@ class StationLiteResource(Resource):
         locations=('query',)
     )
     @with_strict_args(
-        (eidangws.utils.schema.StreamEpochSchema(),),
+        (eidangws.utils.schema.StreamEpochSchema, schema.StationLiteSchema),
         locations=('query',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)
@@ -98,7 +98,7 @@ class StationLiteResource(Resource):
         locations=('form',)
     )
     @with_strict_args(
-        (eidangws.utils.schema.StreamEpochSchema(),),
+        schema.StationLiteSchema,
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/stationlite/server/routes/stationlite.py
+++ b/eidangservices/stationlite/server/routes/stationlite.py
@@ -44,6 +44,7 @@ import eidangservices as eidangws
 from eidangservices import settings, utils
 from eidangservices.utils import fdsnws
 from eidangservices.utils.httperrors import FDSNHTTPError
+from eidangservices.utils.strict import with_strict_args
 from eidangservices.utils.sncl import StreamEpochsHandler, StreamEpoch
 
 from eidangservices.stationlite import __version__
@@ -70,6 +71,10 @@ class StationLiteResource(Resource):
             context={'request': request}),
         locations=('query',)
     )
+    @with_strict_args(
+        (eidangws.utils.schema.StreamEpochSchema(),),
+        locations=('query',)
+    )
     @fdsnws.with_fdsnws_exception_handling(__version__)
     def get(self, args, stream_epochs):
         """
@@ -90,6 +95,10 @@ class StationLiteResource(Resource):
     @fdsnws.use_fdsnws_kwargs(
         eidangws.utils.schema.ManyStreamEpochSchema(
             context={'request': request}),
+        locations=('form',)
+    )
+    @with_strict_args(
+        (eidangws.utils.schema.StreamEpochSchema(),),
         locations=('form',)
     )
     @fdsnws.with_fdsnws_exception_handling(__version__)

--- a/eidangservices/utils/fdsnws.py
+++ b/eidangservices/utils/fdsnws.py
@@ -287,13 +287,12 @@ def register_parser_errorhandler(service_version):
 
 def register_keywordparser_errorhandler(service_version):
     """
-    Register webargs parser `errorhandler
-    <https://webargs.readthedocs.io/en/latest/quickstart.html#error-handling>`_.
+    Register :py:class:`KeywordParser` `errorhandler
     """
     @flask_keywordparser.error_handler
     def handle_parser_error(err, req):
         """
-        configure webargs error handler
+        configure keywordparser error handler
         """
         raise FDSNHTTPError.create(400, service_version=service_version,
                                    error_desc_long=str(err))

--- a/eidangservices/utils/fdsnws.py
+++ b/eidangservices/utils/fdsnws.py
@@ -43,6 +43,7 @@ from webargs.flaskparser import FlaskParser
 from webargs.flaskparser import parser as flaskparser
 
 from eidangservices import settings
+from eidangservices.utils.strict import flask_keywordparser
 from eidangservices.utils.httperrors import FDSNHTTPError
 
 
@@ -284,5 +285,21 @@ def register_parser_errorhandler(service_version):
 
 # register_parser_errorhandler ()
 
+def register_keywordparser_errorhandler(service_version):
+    """
+    Register webargs parser `errorhandler
+    <https://webargs.readthedocs.io/en/latest/quickstart.html#error-handling>`_.
+    """
+    @flask_keywordparser.error_handler
+    def handle_parser_error(err, req):
+        """
+        configure webargs error handler
+        """
+        raise FDSNHTTPError.create(400, service_version=service_version,
+                                   error_desc_long=str(err))
+
+    return handle_parser_error
+
+# register_keywordparser_errorhandler ()
 
 # ---- END OF <fdsnws.py> ----

--- a/eidangservices/utils/strict.py
+++ b/eidangservices/utils/strict.py
@@ -86,7 +86,7 @@ class KeywordParser(object):
         :param dict arg_dict: Dictionary like structure to be parsed
 
         :returns: Tuple with argument keys
-        :rtype: dict
+        :rtype: tuple
         """
 
         return tuple(arg_dict.keys())
@@ -175,8 +175,12 @@ class KeywordParser(object):
 
         if inspect.isclass(schemas):
             schemas = [schemas()]
-        if isinstance(schemas, Schema):
+        elif isinstance(schemas, Schema):
             schemas = [schemas]
+
+        valid_fields = set()
+        for schema in [s() if inspect.isclass(s) else s for s in schemas]:
+            valid_fields.update(schema.fields.keys())
 
         parsers = []
         for l in locations:
@@ -194,16 +198,9 @@ class KeywordParser(object):
         def decorator(*args, **kwargs):
 
             req_args = set()
-            valid_fields = set()
 
             for f in parsers:
                 req_args.update(f(req))
-
-            for s in schemas:
-                if inspect.isclass(s):
-                    valid_fields.update(s().fields.keys())
-                    continue
-                valid_fields.update(s.fields.keys())
 
             invalid_args = req_args.difference(valid_fields)
             if invalid_args:

--- a/eidangservices/utils/strict.py
+++ b/eidangservices/utils/strict.py
@@ -1,0 +1,329 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# This is <strict.py>
+# -----------------------------------------------------------------------------
+#
+# This file is part of EIDA NG webservices.
+#
+# EIDA NG webservices is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# EDIA NG webservices is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----
+#
+# Copyright (c) Sven Marti (ETH), Daniel Armbruster (ETH), Fabian Euchner (ETH)
+#
+# REVISION AND CHANGES
+# 2018/06/05        V0.1    Sven Marti
+# =============================================================================
+"""
+Keywordparser facilities for EIDA NG webservices.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from builtins import * # noqa
+
+import functools
+import inspect
+
+from webargs.flaskparser import parser as flaskparser
+from marshmallow import Schema, exceptions
+
+from eidangservices import settings
+from eidangservices.utils.error import Error
+
+
+class KeywordParserError(Error):
+    """Base KeywordParser error ({})."""
+
+
+class ValidationError(KeywordParserError, exceptions.ValidationError):
+    """ValidationError: {}."""
+    pass
+
+
+def _callable_or_raise(obj):
+    """
+    Makes sure an object is callable if it is not ``None``. If not
+    callable, a ValueError is raised.
+    """
+    if obj and not callable(obj):
+        raise ValueError("{0!r} is not callable.".format(obj))
+    else:
+        return obj
+
+# _callable_or_raise ()
+
+# -----------------------------------------------------------------------------
+class KeywordParserMixin(object):
+    """
+    Mixin providing additional Keywordparser specific parsing facilities.
+    """
+
+    @staticmethod
+    def _parse_arg_keys(arg_dict):
+        """
+        :param dict arg_dict: Dictionary like structure to be parsed
+
+        :returns: Tuple with argument keys
+        :rtype: dict
+        """
+
+        return tuple(arg_dict.keys())
+
+    # _parse_arg_keys ()
+
+    @staticmethod
+    def _parse_postfile(postfile):
+        """
+        Parse all argument keys from a POST request file.
+
+        :param str postfile: Postfile content
+
+        :returns: Tuple with parsed keys.
+        :rtype: tuple
+        """
+        argmap = {}
+
+        for line in postfile.split('\n'):
+            _line = line.split(
+                settings.FDSNWS_QUERY_VALUE_SEPARATOR_CHAR)
+            if len(_line) != 2:
+                continue
+
+            if all(w == '' for w in _line):
+                raise ValidationError('RTFM :)')
+
+            argmap[_line[0]] = _line[1]
+
+        return tuple(argmap.keys())
+
+    # _parse_postfile ()
+
+# class KeywordParserMixin
+
+
+class KeywordParser(KeywordParserMixin):
+    """
+    Base class for keyword parsers.
+    """
+
+    __location_map__ = {
+        'query': 'parse_querystring',
+        'form': 'parse_form'}
+
+    def __init__(self, error_handler=None):
+        self.error_callback = _callable_or_raise(error_handler)
+
+    # __init__ ()
+
+    def parse_querystring(self, req):
+        """
+        Parse argument keys from :code:`req.args`.
+
+        :param req: Request object to be parsed
+        :type req: :py:class:`flask.Request`
+        """
+
+        return self._parse_arg_keys(req.args)
+
+    # parse_querystring ()
+
+    def parse_form(self, req):
+        """
+        :param req: Request object to be parsed
+        :type req: :py:class:`flask.Request`
+        """
+        try:
+            parsed_list = self._parse_postfile(self._get_data(req))
+        except ValidationError as err:
+            if self.error_callback:
+                self.error_callback(err, req)
+            else:
+                self.handle_error(err, req)
+
+        return parsed_list
+
+    # parse_form ()
+
+    def get_default_request(self):
+        """
+        Template function for getting the default request.
+        """
+
+        raise NotImplementedError
+
+    # get_default_request ()
+
+    def parse(self, func, schemas, locations):
+        """
+        Validate request query parameters.
+
+        :param schemas: Marshmallow Schemas to validate request after
+        :type schemas: tuple/list of :py:class:`marshmallow.Schema`
+            or :py:class:`marshmallow.Schema`
+        :param locations:
+        :type locations: tuple of str
+
+        :raises: :py:class:`httperrors.BadRequestError`
+        """
+
+        req = self.get_default_request()
+
+        if isinstance(schemas, Schema):
+            schemas = [schemas]
+
+        parsers = []
+        for l in locations:
+            try:
+                f = self.__location_map__[l]
+                if inspect.isfunction(f):
+                    function = f
+                else:
+                    function = getattr(self, f)
+                parsers.append(function)
+            except KeyError:
+                raise ValueError('Invalid location: {!r}'.format(l))
+
+        @functools.wraps(func)
+        def decorator(*args, **kwargs):
+
+            req_args = set()
+            valid_fields = set()
+
+            for f in parsers:
+                req_args.update(f(req))
+
+            for s in schemas:
+                valid_fields.update(s.fields.keys())
+
+            invalid_args = req_args.difference(valid_fields)
+            if invalid_args:
+                err = ValidationError(
+                    'Invalid request query parameters: {}'.format(
+                        invalid_args))
+
+                if self.error_callback:
+                    self.error_callback(err, req)
+                else:
+                    self.handle_error(err, req)
+
+            return func(*args, **kwargs)
+
+        # decorator ()
+
+        return decorator
+
+    # parse ()
+
+    def with_strict_args(self, schemas, locations=None):
+        """
+        Wrapper of :py:func:`parse`.
+        """
+        return functools.partial(self.parse,
+                                 schemas=schemas,
+                                 locations=locations)
+
+    # with_strict_args ()
+
+    def _get_data(self, req, as_text=True,
+                  max_content_length=settings.MAX_POST_CONTENT_LENGTH):
+        """
+        Savely reads the buffered incoming data from the client.
+
+        :param req: Request the raw data is read from
+        :type req: :py:class:`flask.Request`
+        :param bool as_text: If set to :code:`True` the return value will be a
+            decoded unicode string.
+        :param int max_content_length: Max bytes accepted
+
+        :returns: Byte string or rather unicode string, respectively. Depending
+            on the :code:`as_text` parameter.
+        """
+        if req.content_length > max_content_length:
+            err = ValidationError(
+                'Request too large: {} bytes > {} bytes '.format(
+                    req.content_length, max_content_length))
+
+            if self.error_callback:
+                self.error_callback(err, req)
+            else:
+                self.handle_error(err, req)
+
+        return req.get_data(cache=True, as_text=as_text)
+
+    # _get_data ()
+
+    def handle_error(self, error, req):
+        """
+        Called if an error occurs while parsing args. By default, just logs and
+        raises ``error``.
+        """
+        raise error
+
+    # handle_error ()
+
+    def error_handler(self, func):
+        """
+        Decorator that registers a custom error handling function. The
+        function should received the raised error, request object, and the
+        `marshmallow.Schema` instance used to parse the request. Overrides
+        the parser's ``handle_error`` method.
+
+        Example: ::
+
+            from webargs import flaskparser
+
+            parser = flaskparser.FlaskParser()
+
+
+            class CustomError(Exception):
+                pass
+
+
+            @parser.error_handler
+            def handle_error(error, req, schema):
+                raise CustomError(error.messages)
+
+        :param callable func: The error callback to register.
+        """
+        self.error_callback = func
+        return func
+
+# class KeywordParser
+
+
+# -----------------------------------------------------------------------------
+class FlaskKeywordParser(KeywordParser):
+    """
+    Flask implementation of Keywordparser.
+    """
+
+    def get_default_request(self):
+        """
+        Returns the flask default request
+
+        :returns: :py:class:`flask.Request`
+        """
+
+        return flaskparser.get_default_request()
+
+    # get_default_request ()
+
+# class FlaskKeywordParser
+
+
+flask_keywordparser = FlaskKeywordParser()
+with_strict_args = flask_keywordparser.with_strict_args
+
+
+# ---- END OF <strict.py> ----

--- a/eidangservices/utils/tests/strict.py
+++ b/eidangservices/utils/tests/strict.py
@@ -1,0 +1,305 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# This is <strict.py>
+# -----------------------------------------------------------------------------
+#
+# This file is part of EIDA NG webservices.
+#
+# EIDA NG webservices is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# EIDA NG webservices is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# ----
+#
+# Copyright (c) Daniel Armbruster (ETH), Fabian Euchner (ETH)
+#
+# REVISION AND CHANGES
+# 2017/11/20        V0.1    Daniel Armbruster
+#
+# =============================================================================
+"""
+EIDA NG webservices strict module test facilities.
+"""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+from builtins import * # noqa
+
+import unittest
+
+import flask # noqa
+import marshmallow as ma
+
+from werkzeug.datastructures import MultiDict
+
+from eidangservices.utils import strict
+
+try:
+    import mock
+except ImportError:
+    import unittest.mock as mock
+
+
+# -----------------------------------------------------------------------------
+class KeywordParserMixinTestCase(unittest.TestCase):
+
+    def test_parse_arg_keys(self):
+        arg_dict = MultiDict({'f': 'val',
+                              'b': 'val',
+                              'x': 'val'})
+
+        reference_result = tuple(['f', 'b', 'x'])
+
+        test_result = strict.KeywordParserMixin.\
+            _parse_arg_keys(arg_dict)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_arg_keys ()
+
+    def test_parse_postfile(self):
+        postfile = "f=val\nb=val\nx=val"
+
+        reference_result = tuple(['f', 'b', 'x'])
+
+        test_result = strict.KeywordParserMixin.\
+            _parse_postfile(postfile)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_postfile ()
+
+    def test_parse_postfile_equal(self):
+        postfile = "="
+
+        with self.assertRaises(strict.ValidationError):
+            test_result = strict.KeywordParserMixin.\
+                _parse_postfile(postfile)
+
+    # test_parse_postfile_equal ()
+
+    def test_parse_postfile_empty(self):
+        postfile = ""
+
+        reference_result = tuple()
+
+        test_result = strict.KeywordParserMixin.\
+            _parse_postfile(postfile)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_postfile_empty ()
+
+    def test_parse_postfile_with_sncl(self):
+        postfile = "NL HGN * 2013-10-10 2013-10-11"
+
+        reference_result = tuple()
+
+        test_result = strict.KeywordParserMixin.\
+            _parse_postfile(postfile)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_postfile_with_sncl ()
+
+# class KeywordParserMixinTestCase
+
+
+class KeywordParserTestCase(unittest.TestCase):
+
+    class TestSchema(ma.Schema):
+        f = ma.fields.Str()
+
+    # class TestSchema
+
+    class TestReq(object):
+        pass
+
+    # class TestReq
+
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_get_invalid(self, mock_request_factory):
+        request = self.TestReq()
+        request.method = 'GET'
+        request.args = MultiDict({'f': 'val',
+                                  'b': 'val'})
+
+        mock_request_factory.return_value = request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('query',)
+        )
+        def viewfunc():
+            pass
+
+        with self.assertRaises(strict.ValidationError):
+            viewfunc()
+
+    # test_with_strict_args_get_invalid ()
+
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_get_valid(self, mock_request_factory):
+        request = self.TestReq()
+        request.method = 'GET'
+        request.args = MultiDict({'f': 'val'})
+
+        mock_request_factory.return_value = request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('query',)
+        )
+        def viewfunc():
+            pass
+
+        viewfunc()
+
+    # test_with_strict_args_get_valid ()
+
+    @mock.patch('flask.Request')
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_post_valid(
+        self, mock_request_factory, mock_request
+    ):
+        test_str = b"f=val\nNL HGN ?? * 2013-10-10 2013-10-11"
+        mock_request.method = 'POST'
+        mock_request.get_data.return_value = test_str.decode('utf-8')
+        mock_request.content_length = len(test_str)
+
+        mock_request_factory.return_value = mock_request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('form',)
+        )
+        def viewfunc():
+            pass
+
+        viewfunc()
+
+    # test_with_strict_args_post_valid ()
+
+    @mock.patch('flask.Request')
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_post_invalid(
+        self, mock_request_factory, mock_request
+    ):
+        test_str = b"f=val\nb=val\nNL HGN ?? * 2013-10-10 2013-10-11"
+        mock_request.method = 'POST'
+        mock_request.get_data.return_value = test_str.decode('utf-8')
+        mock_request.content_length = len(test_str)
+
+        mock_request_factory.return_value = mock_request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('form',)
+        )
+        def viewfunc():
+            pass
+
+        with self.assertRaises(strict.ValidationError):
+            viewfunc()
+
+    # test_with_strict_args_post_invalid ()
+
+    @mock.patch('flask.Request')
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_post_only_sncl(
+        self, mock_request_factory, mock_request
+    ):
+        test_str = b"NL HGN ?? * 2013-10-10 2013-10-11"
+        mock_request.method = 'POST'
+        mock_request.get_data.return_value = test_str.decode('utf-8')
+        mock_request.content_length = len(test_str)
+
+        mock_request_factory.return_value = mock_request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('form',)
+        )
+        def viewfunc():
+            pass
+
+        viewfunc()
+
+    # test_with_strict_args_post_only_sncl ()
+
+    @mock.patch('flask.Request')
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_post_empty(
+        self, mock_request_factory, mock_request
+    ):
+        test_str = b""
+        mock_request.method = 'POST'
+        mock_request.get_data.return_value = test_str.decode('utf-8')
+        mock_request.content_length = len(test_str)
+
+        mock_request_factory.return_value = mock_request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('form',)
+        )
+        def viewfunc():
+            pass
+
+        viewfunc()
+
+    # test_with_strict_args_post_empty ()
+
+    @mock.patch('flask.Request')
+    @mock.patch(
+        'eidangservices.utils.strict.flask_keywordparser.get_default_request'
+    )
+    def test_with_strict_args_post_equal(
+        self, mock_request_factory, mock_request
+    ):
+        test_str = b"="
+        mock_request.method = 'POST'
+        mock_request.get_data.return_value = test_str.decode('utf-8')
+        mock_request.content_length = len(test_str)
+
+        mock_request_factory.return_value = mock_request
+
+        @strict.with_strict_args(
+            self.TestSchema(),
+            locations=('form',)
+        )
+        def viewfunc():
+            pass
+
+        with self.assertRaises(strict.ValidationError):
+            viewfunc()
+
+    # test_with_strict_args_post_equal ()
+
+# class KeywordParserTestCase
+
+# -----------------------------------------------------------------------------
+if __name__ == '__main__': # noqa
+    unittest.main()
+
+# ---- END OF <strict.py> ----

--- a/eidangservices/utils/tests/strict.py
+++ b/eidangservices/utils/tests/strict.py
@@ -49,70 +49,6 @@ except ImportError:
 
 
 # -----------------------------------------------------------------------------
-class KeywordParserMixinTestCase(unittest.TestCase):
-
-    def test_parse_arg_keys(self):
-        arg_dict = MultiDict({'f': 'val',
-                              'b': 'val',
-                              'x': 'val'})
-
-        reference_result = tuple(['f', 'b', 'x'])
-
-        test_result = strict.KeywordParserMixin.\
-            _parse_arg_keys(arg_dict)
-
-        self.assertEqual(test_result, reference_result)
-
-    # test_parse_arg_keys ()
-
-    def test_parse_postfile(self):
-        postfile = "f=val\nb=val\nx=val"
-
-        reference_result = tuple(['f', 'b', 'x'])
-
-        test_result = strict.KeywordParserMixin.\
-            _parse_postfile(postfile)
-
-        self.assertEqual(test_result, reference_result)
-
-    # test_parse_postfile ()
-
-    def test_parse_postfile_equal(self):
-        postfile = "="
-
-        with self.assertRaises(strict.ValidationError):
-            test_result = strict.KeywordParserMixin.\
-                _parse_postfile(postfile)
-
-    # test_parse_postfile_equal ()
-
-    def test_parse_postfile_empty(self):
-        postfile = ""
-
-        reference_result = tuple()
-
-        test_result = strict.KeywordParserMixin.\
-            _parse_postfile(postfile)
-
-        self.assertEqual(test_result, reference_result)
-
-    # test_parse_postfile_empty ()
-
-    def test_parse_postfile_with_sncl(self):
-        postfile = "NL HGN * 2013-10-10 2013-10-11"
-
-        reference_result = tuple()
-
-        test_result = strict.KeywordParserMixin.\
-            _parse_postfile(postfile)
-
-        self.assertEqual(test_result, reference_result)
-
-    # test_parse_postfile_with_sncl ()
-
-# class KeywordParserMixinTestCase
-
-
 class KeywordParserTestCase(unittest.TestCase):
 
     class TestSchema(ma.Schema):
@@ -124,6 +60,65 @@ class KeywordParserTestCase(unittest.TestCase):
         pass
 
     # class TestReq
+
+    def test_parse_arg_keys(self):
+        arg_dict = MultiDict({'f': 'val',
+                              'b': 'val',
+                              'x': 'val'})
+
+        reference_result = tuple(['f', 'b', 'x'])
+
+        test_result = strict.KeywordParser.\
+            _parse_arg_keys(arg_dict)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_arg_keys ()
+
+    def test_parse_postfile(self):
+        postfile = "f=val\nb=val\nx=val"
+
+        reference_result = tuple(['f', 'b', 'x'])
+
+        test_result = strict.KeywordParser.\
+            _parse_postfile(postfile)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_postfile ()
+
+    def test_parse_postfile_equal(self):
+        postfile = "="
+
+        with self.assertRaises(strict.ValidationError):
+            test_result = strict.KeywordParser.\
+                _parse_postfile(postfile)
+
+    # test_parse_postfile_equal ()
+
+    def test_parse_postfile_empty(self):
+        postfile = ""
+
+        reference_result = tuple()
+
+        test_result = strict.KeywordParser.\
+            _parse_postfile(postfile)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_postfile_empty ()
+
+    def test_parse_postfile_with_sncl(self):
+        postfile = "NL HGN * 2013-10-10 2013-10-11"
+
+        reference_result = tuple()
+
+        test_result = strict.KeywordParser.\
+            _parse_postfile(postfile)
+
+        self.assertEqual(test_result, reference_result)
+
+    # test_parse_postfile_with_sncl ()
 
     @mock.patch(
         'eidangservices.utils.strict.flask_keywordparser.get_default_request'


### PR DESCRIPTION
Implemented a KeywordParser for request argument validation.
The KeywordParser is usable trough the decorator `@with_strict_args`,
which takes schemas to validate and a location parameter.
If any request arguments don't match with the expected schema arguments,
a ValidationError is thrown.

The KeywordParser is inspired by webargs: https://github.com/sloria/webargs
This new implementation can be found in `eidangservices/utils/strict.py`.

References: #44
Closes: #44

 