### PR TITLE
Add CORS headers to federator

### DIFF
--- a/eidangservices/federator/server/__init__.py
+++ b/eidangservices/federator/server/__init__.py
@@ -33,6 +33,7 @@ from builtins import * # noqa
 import datetime
 
 from flask import Flask, make_response, g
+from flask_cors import CORS
 
 # from werkzeug.contrib.profiler import ProfilerMiddleware
 
@@ -51,6 +52,8 @@ def create_app(config_dict={}, service_version=__version__):
     """
     app = Flask(__name__)
     app.config.update(config_dict)
+    # allows CORS for all domains for all routes
+    CORS(app)
 
     # app.config['PROFILE'] = True
     # app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[10])

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ _includes = ('*')
 _deps_all = [
     'Flask>=0.12.2',
     'Flask-RESTful>=0.3.6',
-    'Flask-Cors>=3.0.7',
     # TODO(damb): Seems not to work for Python 2.7
     # 'mock:python_version<"3.3"',
     'future>=0.16.0',
@@ -82,6 +81,7 @@ _deps_all = [
     'requests>=2.18.4',
     'webargs==3.0.0', ]
 _deps_federator = _deps_all + [
+    'Flask-Cors>=3.0.7',
     'ijson>=2.3', ]
 _deps_stationlite = _deps_all + [
     'fasteners>=0.14.1',

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ _includes = ('*')
 _deps_all = [
     'Flask>=0.12.2',
     'Flask-RESTful>=0.3.6',
+    'Flask-Cors>=3.0.7',
     # TODO(damb): Seems not to work for Python 2.7
     # 'mock:python_version<"3.3"',
     'future>=0.16.0',


### PR DESCRIPTION
The CORS header worked for me (I have not tested the setup.py because Docker pulls from master). I've removed the header from `stationlite` because we only use it internally.