### PR TITLE
Add x forwarded header

### DIFF
--- a/eidangservices/federator/server/request.py
+++ b/eidangservices/federator/server/request.py
@@ -41,6 +41,8 @@ from urllib.parse import urlparse, urlunparse
 
 import requests
 
+from flask import request
+
 from eidangservices import settings, utils
 from eidangservices.utils.schema import StreamEpochSchema
 from eidangservices.federator import __version__
@@ -57,6 +59,7 @@ class RequestHandlerBase(object):
 
     """
     HEADERS = {"user-agent": "EIDA-Federator/" + __version__,
+               "X-Forwarded-For": request.remote_addr,
                # force no encoding, because eida-federator currently cannot
                # handle this
                "Accept-Encoding": ""}

--- a/eidangservices/federator/server/request.py
+++ b/eidangservices/federator/server/request.py
@@ -59,7 +59,7 @@ class RequestHandlerBase(object):
 
     """
     HEADERS = {"user-agent": "EIDA-Federator/" + __version__,
-               "X-Forwarded-For": request.remote_addr,
+               "X-Forwarded-For": request.access_route[-1],
                # force no encoding, because eida-federator currently cannot
                # handle this
                "Accept-Encoding": ""}


### PR DESCRIPTION
Maybe something like this? The `request.access_route` returns a list of all the IP addresses and proxies in between with the last one being the original address. Since our Federator is behind a proxy it was just showing our own IP when I used `request.remote_addr`.