### PR TITLE
Update Dockerfile; config to use psql

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,4 @@
+POSTGRES_USER=user
+POSTGRES_PASSWORD=pass
+POSTGRES_HOST=stationlite-psql
+POSTGRES_DB=stationlite

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,9 +86,8 @@ RUN mkdir /etc/service/apache2 && \
 	echo "#!/bin/sh\nexec apachectl -D FOREGROUND" > /etc/service/apache2/run && \
 	chmod +x /etc/service/apache2/run
 
-# Add the harvesting cronjob (once per day) at runtime using env variables
-RUN echo "#!/bin/bash\n(crontab -l ; echo \"0 1 * * * /var/www/stationlite/venv3/bin/eida-stationlite-harvest postgresql://\$POSTGRES_USER:\$POSTGRES_PASSWORD@\$POSTGRES_HOST:5432/\$POSTGRES_DB\") | crontab" > /etc/my_init.d/harvest-cron.sh && \
-    chmod a+x /etc/my_init.d/harvest-cron.sh
+# Add the harvesting cronjob (once per day)
+RUN (crontab -l ; echo "0 1 * * * /var/www/stationlite/venv3/bin/eida-stationlite-harvest --config /var/www/mediatorws/config/eidangws_config") | crontab
 
 RUN mkdir -p /var/www/mediatorws/log && chown www-data:www-data /var/www/mediatorws/log
 RUN mkdir -p /var/www/mediatorws/db && chown www-data:www-data /var/www/mediatorws/db

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -86,10 +86,9 @@ RUN mkdir /etc/service/apache2 && \
 	echo "#!/bin/sh\nexec apachectl -D FOREGROUND" > /etc/service/apache2/run && \
 	chmod +x /etc/service/apache2/run
 
-# Add the harvesting cronjob (once per day)
-RUN (crontab -l ; echo "0 1 * * * \
-     /var/www/stationlite/venv3/bin/eida-stationlite-harvest \
-     postgresql://user:pass@localhost:5432/stationlite") | crontab
+# Add the harvesting cronjob (once per day) at runtime using env variables
+RUN echo "#!/bin/bash\n(crontab -l ; echo \"0 1 * * * /var/www/stationlite/venv3/bin/eida-stationlite-harvest postgresql://\$POSTGRES_USER:\$POSTGRES_PASSWORD@\$POSTGRES_HOST:5432/\$POSTGRES_DB\") | crontab" > /etc/my_init.d/harvest-cron.sh && \
+    chmod a+x /etc/my_init.d/harvest-cron.sh
 
 RUN mkdir -p /var/www/mediatorws/log && chown www-data:www-data /var/www/mediatorws/log
 RUN mkdir -p /var/www/mediatorws/db && chown www-data:www-data /var/www/mediatorws/db

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y libxml2-dev \
                                          zlib* \
                                          python-pip \
                                          pkg-config \
+                                         libpg-dev \
                                          libpng-dev \
                                          libfreetype6-dev \
                                          libblas-dev \
@@ -59,6 +60,7 @@ RUN mkdir /var/www/federator && cd /var/www/federator && \
 RUN mkdir /var/www/stationlite && cd /var/www/stationlite && \
     virtualenv -p $(which python3.5) venv3 && \
     /bin/bash -c "source /var/www/stationlite/venv3/bin/activate && \
+    pip install psycopg2 && \
     make -C /var/www/mediatorws install SERVICES=stationlite && deactivate"
 
 # Copy Apache configuration configuration
@@ -87,7 +89,7 @@ RUN mkdir /etc/service/apache2 && \
 # Add the harvesting cronjob (once per day)
 RUN (crontab -l ; echo "0 1 * * * \
      /var/www/stationlite/venv3/bin/eida-stationlite-harvest \
-     sqlite:////var/www/mediatorws/db/stationlite.db") | crontab
+     postgresql://user:pass@localhost:5432/stationlite") | crontab
 
 RUN mkdir -p /var/www/mediatorws/log && chown www-data:www-data /var/www/mediatorws/log
 RUN mkdir -p /var/www/mediatorws/db && chown www-data:www-data /var/www/mediatorws/db

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,16 +3,14 @@ services:
 
   # The federator service
   federator:
+    container_name: federator
     image: eida-federator:1.0 
     restart: always
 
     # psql connection details
     # TODO modify db_engine and db_url in configuration
-    environment:
-      - POSTGRES_USER=user
-      - POSTGRES_PASSWORD=pass
-      - POSTGRES_HOST=localhost
-      - POSTGRES_DB=stationlite
+    env_file:
+      - .env
     volumes:
       - type: volume
         source: mediatorws_log
@@ -34,7 +32,10 @@ services:
 
   # For the stationlite psql database
   psql:
+    container_name: stationlite-psql
     image: postgres:11
+    env_file:
+      - .env
     restart: always
     volumes:
       - /var/db/psql:/var/lib/postgresql/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,14 @@ services:
   federator:
     image: eida-federator:1.0 
     restart: always
+
+    # psql connection details
+    # TODO modify db_engine and db_url in configuration
+    environment:
+      - POSTGRES_USER=user
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_HOST=localhost
+      - POSTGRES_DB=stationlite
     volumes:
       - type: volume
         source: mediatorws_log

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3.3'
 services:
+
+  # The federator service
   federator:
     image: eida-federator:1.0 
     restart: always
@@ -21,6 +23,15 @@ services:
           nocopy: false
     ports:
       - "8080:80"
+
+  # For the stationlite psql database
+  psql:
+    image: postgres:11
+    restart: always
+    volumes:
+      - /var/db/psql:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
 
 volumes:
   mediatorws_log:

--- a/docker/eidangws_config
+++ b/docker/eidangws_config
@@ -92,7 +92,7 @@ path_logging_conf=/var/www/mediatorws/config/fed-logging.conf
 # See also:
 # http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
 #
-db_url = sqlite:////var/www/mediatorws/db/stationlite.db
+db_url = postgresql://user:pass@localhost:5432/stationlite
 #
 # ----
 # Set the path to a logging configuration file. For information on howto setup
@@ -156,6 +156,6 @@ path_logging_conf=/var/www/mediatorws/config/harvest-logging.conf
 # See also:
 # http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
 #
-# db_engine = sqlite:////abs/path/to/stationlite.db
+db_engine = postgresql://user:pass@localhost:5432/stationlite
 #
 # ---- END OF <eidangws_config> ----

--- a/docker/eidangws_config
+++ b/docker/eidangws_config
@@ -92,7 +92,7 @@ path_logging_conf=/var/www/mediatorws/config/fed-logging.conf
 # See also:
 # http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
 #
-db_url = postgresql://user:pass@localhost:5432/stationlite
+db_url = postgresql://user:pass@stationlite-psql:5432/stationlite
 #
 # ----
 # Set the path to a logging configuration file. For information on howto setup
@@ -156,6 +156,6 @@ path_logging_conf=/var/www/mediatorws/config/harvest-logging.conf
 # See also:
 # http://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls
 #
-db_engine = postgresql://user:pass@localhost:5432/stationlite
+db_engine = postgresql://user:pass@stationlite-psql:5432/stationlite
 #
 # ---- END OF <eidangws_config> ----

--- a/docs/installing/docker.rst
+++ b/docs/installing/docker.rst
@@ -26,7 +26,37 @@ versions of Windows) and on how to install Docker, please refer to the official
 
 To construct a Docker image with the appropriate configuration it is
 recommended to build your image from a Dockerfile. After cloning the repository
-change into the :code:`docker/` directory and build the image:
+change into the :code:`docker/` directory and change the configuration.
+
+**Postgres**:
+
+The docker distribution uses stationlite with postgres. You are required to set
+up and initial empty postgres database that can be used by stationlite. Make
+sure to pick a proper username and password and write these down. A volume
+must be mounted where the postgres data will be stored with the -v flag. The
+volume must match what is configured in the *docker-compose.yml* file.
+
+.. code::
+
+  $ docker run --rm -e POSTGRES_USER=user \
+                    -e POSTGRES_PASSWORD=pass \
+                    -e POSTGRES_DB=stationlite \
+                    -v /var/db/psql:/var/lib/postgresql/data \
+                    postgres:11
+
+
+Follow up by configuring the following parameters in docker/eidangws_config
+with your postgres parameters. The host localhost must be replaced with the name
+of the postgres container (e.g. docker_psql_1).
+
+.. code::
+
+  $ cd docker
+  db_url = postgresql://user:pass@localhost:5432/stationlite
+  db_engine = postgresql://user:pass@localhost:5432/stationlite
+
+Other important configuration parameters are for logging. Once the configuration
+is complete continue by building the image:
 
 .. code::
 
@@ -41,14 +71,24 @@ configuration file.
 
   $ docker-compose up -d
 
-When deploying for the first time you are required to kickstart the harvesting for
-*stationlite*:
+When deploying for the first time you are required to initialize the database for
+*stationlite*. This will create the database schema.
+
+.. code::
+
+  $ docker exec <container_name> \
+      /var/www/stationlite/venv3/bin/eida-stationlite-db-init \
+      postgresql://user:pass@localhost:5432/stationlite
+
+and the harvesting:
 
 .. code::
 
   $ docker exec <container_name> \
       /var/www/stationlite/venv3/bin/eida-stationlite-harvest \
-      sqlite:////var/www/mediatorws/db/stationlite.db
+      postgresql://user:pass@localhost:5432/stationlite
 
 The initial harvesting may take some time. In the future it will be run by a daily cronjob.
-The services are now available under :code:`http://localhost:8080`.
+
+When the containers are running the services are now available under
+:code:`http://localhost:8080`.

--- a/docs/installing/docker.rst
+++ b/docs/installing/docker.rst
@@ -3,7 +3,7 @@ Deploying the EIDA NG Federator as a Docker container
 
 .. note::
 
-  Currently only *federator* and *stationlite*.
+  Currently includes *federator* and *stationlite*.
 
 A basic knowledge about `Docker <https://docs.docker.com/engine/>`__ and how
 this kind of application containers work is required. For more information
@@ -19,25 +19,27 @@ versions of Windows) and on how to install Docker, please refer to the official
 * *federator* and *stationlite* are set up separately i.e. each
   service is installed into its own virtual environment
 * services use Python3
-* *stationlite* harvesting via :code:`cron`
+* *stationlite* harvesting via :code:`cron` powered by postgres
 * logging (file based)
 
-**Building**:
+**Introduction**:
 
 To construct a Docker image with the appropriate configuration it is
 recommended to build your image from a Dockerfile. After cloning the repository
-change into the :code:`docker/` directory and change the configuration.
+change into the :code:`docker/` directory and modify the configuration.
 
 **Postgres**:
 
-The docker distribution uses stationlite with postgres. You are required to set
-up and initial empty postgres database that can be used by stationlite. Make
-sure to pick a proper username and password and write these down. A volume
-must be mounted where the postgres data will be stored with the -v flag. The
-volume must match what is configured in the *docker-compose.yml* file.
+The docker distribution of the Federator uses stationlite with postgres.
+You are required to set up and initial empty postgres database that can be
+used by stationlite. Make sure to pick a proper username and password and write
+these down for later. A volume must be mounted where the postgres data will be
+stored with the -v flag. The postgres volume must match what is later configured 
+inside the *docker-compose.yml* file.
 
 .. code::
 
+  # Set variables and a place to mount the data
   $ docker run --rm -e POSTGRES_USER=user \
                     -e POSTGRES_PASSWORD=pass \
                     -e POSTGRES_DB=stationlite \
@@ -47,10 +49,11 @@ volume must match what is configured in the *docker-compose.yml* file.
 
 Follow up by configuring the following parameters in docker/eidangws_config
 with your postgres parameters. The host localhost must be replaced with the name
-of the postgres container (e.g. docker_psql_1).
+of the postgres container (e.g. docker_psql_1) and the same credentials.
 
 .. code::
 
+  # TODO load these dynamically from environment variables
   $ cd docker
   db_url = postgresql://user:pass@localhost:5432/stationlite
   db_engine = postgresql://user:pass@localhost:5432/stationlite
@@ -61,6 +64,12 @@ is complete continue by building the image:
 .. code::
 
   $ cd docker && docker build -t eida-federator:1.0 .
+
+**Compose Configuration**:
+
+Modify docker-compose.yml to fill in the environment variables that you chose for
+your postgres installation. In case you want to manage your own volumes now is
+the time.
 
 **Deployment**:
 


### PR DESCRIPTION
Currently we don't have a good way to pass environment variables to:

- crontab harvesting
- eidawsng_config

Maybe we should describe the manual postgres setup & federator configuration in a section in the Docker documentation?