### PR TITLE
Configurable request strategies

### DIFF
--- a/config/eidangws_config
+++ b/config/eidangws_config
@@ -29,18 +29,29 @@
 # endpoint_resources = fdsnws-dataselect fdsnws-station eidaws-wfcatalog
 #
 # ----
-# Configure the number of download threads/request by means of a dictionary
-# (JSON syntax required). The default configuration is:
-# '{"fdsnws-dataselect": 10, "fdsnws-station-xml": 5,
-#   "fdsnws-station-text": 10, "eidaws-wfcatalog": 10}'
+# Configure federator resources (JSON syntax required). The default
+# configuration is:
 #
-# NOTE: For "fdsnws-station-xml" the number of download threads refers to the
-# number of download threads per network code.
-#
-# endpoint_threads = '{"fdsnws-dataselect": 10,
-#                      "fdsnws-station-xml": 5,
-#                      "fdsnws-station-text": 10,
-#                      "eidaws-wfcatalog": 10}'
+# resource_config='{
+#  "fdsnws-dataselect":
+#   {"num_threads": 10,
+#    "request_strategy": "granular",
+#    "request_method": "POST"},
+#  "fdsnws-station-xml":
+#   {"num_threads": 5,
+#    "request_strategy": "adaptive-bulk",
+#    "request_method": "POST"},
+#  "fdsnws-station-text": 
+#   {"num_threads": 10,
+#    "request_strategy": "bulk",
+#    "request_method": "POST"},
+#  "eidaws-wfcatalog":
+#   {"num_threads": 10,
+#    "request_strategy": "granular",
+#    "request_method": "POST"}}'
+# 
+# NOTE: For "fdsnws-station-xml" the number of download threads ("num_threads")
+# scales squared.
 #
 # ----
 # Configure where temporary files will be located.

--- a/docker/eidangws_config
+++ b/docker/eidangws_config
@@ -29,18 +29,29 @@
 # endpoint_resources = fdsnws-dataselect fdsnws-station eidaws-wfcatalog
 #
 # ----
-# Configure the number of download threads/request by means of a dictionary
-# (JSON syntax required). The default configuration is:
-# '{"fdsnws-dataselect": 10, "fdsnws-station-xml": 5,
-#   "fdsnws-station-text": 10, "eidaws-wfcatalog": 10}'
+# Configure federator resources (JSON syntax required). The default
+# configuration is:
 #
-# NOTE: For "fdsnws-station-xml" the number of download threads refers to the
-# number of download threads per network code.
-#
-# endpoint_threads = '{"fdsnws-dataselect": 10,
-#                      "fdsnws-station-xml": 5,
-#                      "fdsnws-station-text": 10,
-#                      "eidaws-wfcatalog": 10}'
+# resource_config='{
+#  "fdsnws-dataselect":
+#   {"num_threads": 10,
+#    "request_strategy": "granular",
+#    "request_method": "POST"},
+#  "fdsnws-station-xml":
+#   {"num_threads": 5,
+#    "request_strategy": "adaptive-bulk",
+#    "request_method": "POST"},
+#  "fdsnws-station-text": 
+#   {"num_threads": 10,
+#    "request_strategy": "bulk",
+#    "request_method": "POST"},
+#  "eidaws-wfcatalog":
+#   {"num_threads": 10,
+#    "request_strategy": "granular",
+#    "request_method": "POST"}}'
+# 
+# NOTE: For "fdsnws-station-xml" the number of download threads ("num_threads")
+# scales squared.
 #
 # ----
 # Configure where temporary files will be located.

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -136,7 +136,7 @@ class RequestProcessor:
         """Factory method for RequestProcessor object instances.
 
         :param str service: Service identifier.
-        :param dict kwargs: A dictionary passed to the combiner constructors.
+        :param dict kwargs: A dictionary passed to processor constructors.
         :return: A concrete :py:class:`RequestProcessor` implementation
         :rtype: :py:class:`RequestProcessor`
         :raises KeyError: if an invalid format string was passed

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -75,6 +75,8 @@ class RequestProcessor:
         :type request_strategy: :py:class:`RequestStrategyBase`
         :param keep_tempfiles: Flag indicating how to treat temporary files
         :type keep_tempfiles: :py:class:`KeepTempfiles`
+        :param str http_method: HTTP method used when issuing requests to
+            endpoints
         """
 
         self.mimetype = mimetype
@@ -112,6 +114,8 @@ class RequestProcessor:
         self._strategy = self._strategy(
             context=self._ctx, default_endtime=self.DEFAULT_ENDTIME)
 
+        self._http_method = kwargs.get(
+            'http_method', settings.EIDA_FEDERATOR_DEFAULT_HTTP_METHOD)
         self._nodata = int(self.query_params.get(
             'nodata', settings.FDSN_DEFAULT_NO_CONTENT_ERROR_CODE))
 
@@ -332,7 +336,8 @@ class RawRequestProcessor(RequestProcessor):
         self._results = self._strategy.request(
             self._pool, tasks={'default': RawDownloadTask},
             query_params=self.query_params,
-            keep_tempfiles=self._keep_tempfiles)
+            keep_tempfiles=self._keep_tempfiles,
+            http_method=self._http_method)
 
     def _handle_413(self, result):
         self.logger.info(
@@ -568,7 +573,8 @@ class StationXMLRequestProcessor(StationRequestProcessor):
             self._pool, tasks={'default': StationXMLDownloadTask,
                                'combining': StationXMLNetworkCombinerTask},
             query_params=self.query_params,
-            keep_tempfiles=self._keep_tempfiles)
+            keep_tempfiles=self._keep_tempfiles,
+            http_method=self._http_method)
 
         self._pool.close()
 
@@ -701,7 +707,8 @@ class StationTextRequestProcessor(StationRequestProcessor):
         self._results = self._strategy.request(
             self._pool, tasks={'default': StationTextDownloadTask},
             query_params=self.query_params,
-            keep_tempfiles=self._keep_tempfiles)
+            keep_tempfiles=self._keep_tempfiles,
+            http_method=self._http_method)
 
         self._pool.close()
 
@@ -811,7 +818,8 @@ class WFCatalogRequestProcessor(RequestProcessor):
         self._results = self._strategy.request(
             self._pool, tasks={'default': RawDownloadTask},
             query_params=self.query_params,
-            keep_tempfiles=self._keep_tempfiles)
+            keep_tempfiles=self._keep_tempfiles,
+            http_method=self._http_method)
 
     def _handle_413(self, result):
         self.logger.info(

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -90,9 +90,7 @@ class RequestProcessor:
         # TODO(damb): Pass as ctor arg.
         self._routing_service = current_app.config['ROUTING_SERVICE']
 
-        self._logger = logging.getLogger(
-            self.LOGGER if kwargs.get('logger') is None
-            else kwargs.get('logger'))
+        self._logger = logging.getLogger(kwargs.get('logger', self.LOGGER))
 
         self._ctx = kwargs.get('context', Context(uuid.uuid4()))
         if not self._ctx.locked:

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -543,8 +543,7 @@ class StationRequestProcessor(RequestProcessor):
         # NOTE(damb): We group routes by network code, first. This later will
         # enable us to easier provide station metadata combination for
         # distributed physical networks. However, currently we exclusively
-        # combine station-xml. For station-text we issue still granular
-        # download tasks.
+        # combine station-xml.
         # Afterwards, grouped routes are multiplex by network code, again.
 
         retval = collections.defaultdict(list)

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -178,8 +178,8 @@ class RequestProcessor:
         Create the routing table using the routing service provided.
         """
         routing_request = RoutingRequestHandler(
-            self._routing_service, self.query_params,
-            self.stream_epochs)
+            self._routing_service, self.stream_epochs,
+            self.query_params)
 
         req = (routing_request.post() if self.post else routing_request.get())
         self.logger.info("Fetching routes from %s" % routing_request.url)

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -683,8 +683,7 @@ class StationTextRequestProcessor(StationRequestProcessor):
         super().__init__(mimetype, query_params, stream_epochs, post, **kwargs)
 
         self._level = query_params.get('level')
-        if self._level is None:
-            raise RequestProcessorError("Missing parameter: 'level'.")
+        assert self._level, "Missing parameter: 'level'"
 
     @property
     def POOL_SIZE(self):

--- a/eidangservices/federator/server/request.py
+++ b/eidangservices/federator/server/request.py
@@ -19,12 +19,6 @@ class RequestHandlerBase:
     """
     RequestHandler base class implementation. Provides bulk request handling
     facilities.
-
-    :param str url: URL
-    :param dict query_params: Dictionary of query parameters
-    :param list stream_epochs: List of
-        :py:class:`eidangservices.utils.sncl.StreamEpoch` objects
-
     """
 
     HEADERS = {"user-agent": "EIDA-Federator/" + __version__,
@@ -33,6 +27,14 @@ class RequestHandlerBase:
                "Accept-Encoding": ""}
 
     def __init__(self, url, query_params={}, stream_epochs=[]):
+        """
+        :param url: URL
+        :type url: str or bytes
+        :param dict query_params: Dictionary of query parameters
+        :param list stream_epochs: List of
+            :py:class:`eidangservices.utils.sncl.StreamEpoch` objects
+        """
+
         if isinstance(url, bytes):
             url = url.decode('utf-8')
         url = urlparse(url)

--- a/eidangservices/federator/server/request.py
+++ b/eidangservices/federator/server/request.py
@@ -15,6 +15,21 @@ from eidangservices.utils.schema import StreamEpochSchema
 from eidangservices.federator import __version__
 
 
+def _query_params_from_stream_epochs(stream_epochs):
+    serializer = StreamEpochSchema(many=True, context={'request': _GET})
+
+    return utils.convert_sncl_dicts_to_query_params(
+        serializer.dump(stream_epochs))
+
+
+class _GET:
+    """
+    Utility class emulating a GET request.
+    """
+    method = 'GET'
+
+
+# -----------------------------------------------------------------------------
 class RequestHandlerBase:
     """
     RequestHandler base class implementation. Provides bulk request handling
@@ -26,13 +41,13 @@ class RequestHandlerBase:
                # handle this
                "Accept-Encoding": ""}
 
-    def __init__(self, url, query_params={}, stream_epochs=[]):
+    def __init__(self, url, stream_epochs=[], query_params={}):
         """
         :param url: URL
         :type url: str or bytes
-        :param dict query_params: Dictionary of query parameters
         :param list stream_epochs: List of
             :py:class:`eidangservices.utils.sncl.StreamEpoch` objects
+        :param dict query_params: Dictionary of query parameters
         """
 
         if isinstance(url, bytes):
@@ -95,12 +110,6 @@ class RequestHandlerBase:
 class RoutingRequestHandler(RequestHandlerBase):
     """
     Representation of a `eidaws-routing` request handler.
-
-    .. note::
-
-        Since both `eidaws-routing` and `eida-stationlite` implement the same
-        interface :py:class:`RoutingRequestHandler` may be used for both
-        webservices.
     """
 
     QUERY_PARAMS = set(('service',
@@ -110,14 +119,8 @@ class RoutingRequestHandler(RequestHandlerBase):
                         'minlongitude', 'minlon',
                         'maxlongitude', 'maxlon'))
 
-    class GET:
-        """
-        Utility class emulating a GET request.
-        """
-        method = 'GET'
-
-    def __init__(self, url, query_params={}, stream_epochs=[]):
-        super().__init__(url, query_params, stream_epochs)
+    def __init__(self, url, stream_epochs=[], query_params={}):
+        super().__init__(url, stream_epochs, query_params)
 
         self._query_params = dict(
             (p, v) for p, v in self._query_params.items()
@@ -127,11 +130,8 @@ class RoutingRequestHandler(RequestHandlerBase):
 
     @property
     def payload_get(self):
-        se_schema = StreamEpochSchema(many=True, context={'request': self.GET})
-
         qp = deepcopy(self._query_params)
-        qp.update(utils.convert_sncl_dicts_to_query_params(
-                  se_schema.dump(self._stream_epochs)))
+        qp.update(_query_params_from_stream_epochs(self._stream_epochs))
         return qp
 
     def get(self):
@@ -151,9 +151,9 @@ class FdsnRequestHandler(RequestHandlerBase):
                         'minlongitude', 'minlon',
                         'maxlongitude', 'maxlon'))
 
-    def __init__(self, url, query_params={}, stream_epochs=[]):
-        super().__init__(url, query_params=query_params,
-                         stream_epochs=stream_epochs)
+    def __init__(self, url, stream_epochs=[], query_params={}):
+        super().__init__(url, stream_epochs=stream_epochs,
+                         query_params=query_params)
         self._query_params = dict((p, v)
                                   for p, v in self._query_params.items()
                                   if p not in self.QUERY_PARAMS)
@@ -166,13 +166,24 @@ class GranularFdsnRequestHandler(FdsnRequestHandler):
     """
 
     def __init__(self, url, stream_epoch, query_params={}):
-        super().__init__(url, query_params, [stream_epoch])
+        super().__init__(url, stream_epochs=[stream_epoch],
+                         query_params=query_params)
 
     @property
     def payload_post(self):
         data = '\n'.join('{}={}'.format(p, v)
                          for p, v in self._query_params.items())
         return '{}\n{}'.format(data, self.stream_epochs[0])
+
+    @property
+    def payload_get(self):
+        qp = deepcopy(self._query_params)
+        qp.update(_query_params_from_stream_epochs(self._stream_epochs))
+        return qp
+
+    def get(self):
+        return functools.partial(requests.get, self.url,
+                                 params=self.payload_get, headers=self.HEADERS)
 
 
 BulkFdsnRequestHandler = FdsnRequestHandler

--- a/eidangservices/federator/server/routes/dataselect.py
+++ b/eidangservices/federator/server/routes/dataselect.py
@@ -59,6 +59,7 @@ class DataselectResource(Resource):
             post=False,
             context=g.ctx,
             keep_tempfiles=current_app.config['FED_KEEP_TEMPFILES'],
+            **current_app.config['FED_RESOURCE_CONFIG']['fdsnws-dataselect'],
         ).streamed_response
 
     @fdsnws.use_fdsnws_args(DataselectSchema(), locations=('form',))
@@ -90,4 +91,5 @@ class DataselectResource(Resource):
             post=True,
             context=g.ctx,
             keep_tempfiles=current_app.config['FED_KEEP_TEMPFILES'],
+            **current_app.config['FED_RESOURCE_CONFIG']['fdsnws-dataselect'],
         ).streamed_response

--- a/eidangservices/federator/server/routes/station.py
+++ b/eidangservices/federator/server/routes/station.py
@@ -50,6 +50,8 @@ class StationResource(Resource):
         args = s.dump(args)
         self.logger.debug('StationSchema (serialized): %s' % args)
 
+        resource_cfg = 'fdsnws-station-' + args['format']
+
         # process request
         return RequestProcessor.create(
             args['service'],
@@ -59,6 +61,7 @@ class StationResource(Resource):
             post=False,
             context=g.ctx,
             keep_tempfiles=current_app.config['FED_KEEP_TEMPFILES'],
+            **current_app.config['FED_RESOURCE_CONFIG'][resource_cfg]
         ).streamed_response
 
     @fdsnws.use_fdsnws_args(StationSchema(), locations=('form',))
@@ -80,6 +83,7 @@ class StationResource(Resource):
         args = s.dump(args)
         self.logger.debug('StationSchema (serialized): %s' % args)
 
+        resource_cfg = 'fdsnws-station-' + args['format']
         # process request
         return RequestProcessor.create(
             args['service'],
@@ -89,6 +93,7 @@ class StationResource(Resource):
             post=True,
             context=g.ctx,
             keep_tempfiles=current_app.config['FED_KEEP_TEMPFILES'],
+            **current_app.config['FED_RESOURCE_CONFIG'][resource_cfg]
         ).streamed_response
 
     def _get_result_mimetype(self, args):

--- a/eidangservices/federator/server/routes/wfcatalog.py
+++ b/eidangservices/federator/server/routes/wfcatalog.py
@@ -74,6 +74,7 @@ class WFCatalogResource(Resource):
             post=False,
             context=g.ctx,
             keep_tempfiles=current_app.config['FED_KEEP_TEMPFILES'],
+            **current_app.config['FED_RESOURCE_CONFIG']['eidaws-wfcatalog'],
         ).streamed_response
 
     @fdsnws.use_fdsnws_args(WFCatalogSchema(), locations=('form',))
@@ -109,4 +110,5 @@ class WFCatalogResource(Resource):
             post=True,
             context=g.ctx,
             keep_tempfiles=current_app.config['FED_KEEP_TEMPFILES'],
+            **current_app.config['FED_RESOURCE_CONFIG']['eidaws-wfcatalog'],
         ).streamed_response

--- a/eidangservices/federator/server/strategy.py
+++ b/eidangservices/federator/server/strategy.py
@@ -1,0 +1,409 @@
+# -*- coding: utf-8 -*-
+"""
+Facilities for route based requesting strategies.
+"""
+
+import collections
+import datetime
+import logging
+
+from eidangservices import utils, settings
+from eidangservices.federator import __version__
+from eidangservices.federator.server.misc import (
+    Context, ContextLoggerAdapter)
+from eidangservices.federator.server.request import (
+    GranularFdsnRequestHandler, BulkFdsnRequestHandler)
+from eidangservices.utils.httperrors import FDSNHTTPError
+from eidangservices.utils.request import (binary_request, RequestsError,
+                                          NoContent)
+from eidangservices.utils.error import ErrorWithTraceback
+from eidangservices.utils.sncl import StreamEpoch
+
+
+def demux_routes(routing_table):
+    return [utils.Route(url, streams=[se])
+            for url, streams in routing_table.items()
+            for se in streams]
+
+
+def group_routes_by(routing_table, key='network'):
+    """
+    Group routes by a certain :py:class:`eidangservices.sncl.Stream` keyword.
+    Combined keywords are also possible e.g. network.station. When combining
+    keys the seperating character is `.`. Routes are demultiplexed.
+
+    :param dict routing_table: Routing table
+    :param str key: Key used for grouping.
+    """
+    SEP = '.'
+
+    routes = demux_routes(routing_table)
+    retval = collections.defaultdict(list)
+
+    for route in routes:
+        try:
+            _key = getattr(route.streams[0].stream, key)
+        except AttributeError:
+            try:
+                if SEP in key:
+                    # combined key
+                    _key = SEP.join(getattr(route.streams[0].stream, k)
+                                    for k in key.split(SEP))
+                else:
+                    raise KeyError(
+                        'Invalid separator. Must be {!r}.'.format(SEP))
+            except (AttributeError, KeyError) as err:
+                raise RequestStrategyError(err)
+
+        retval[_key].append(route)
+
+    return retval
+
+
+def _mux_routes(routing_table):
+    retval = collections.defaultdict(list)
+    for net, _routes in group_routes_by(
+            routing_table, key='network').items():
+        # sort by url
+        mux_routes = collections.defaultdict(list)
+        for r in _routes:
+            mux_routes[r.url].append(r.streams[0])
+
+        for url, ses in mux_routes.items():
+            retval[net].append(utils.Route(url=url, streams=ses))
+
+    return retval
+
+
+class RequestStrategyError(ErrorWithTraceback):
+    """Base RequestStrategy error ({})."""
+
+
+class RoutingError(RequestStrategyError):
+    """Error while routing ({})."""
+
+
+# -----------------------------------------------------------------------------
+class RequestStrategyBase:
+    """
+    Request strategy encapsulating routing and requesting.
+    """
+
+    LOGGER = "flask.app.federator.strategy"
+
+    def __init__(self, **kwargs):
+        """
+        :param ctx: Request context the strategy is used
+
+        :param default_endtime: Default endtime to be used if the stream epochs
+            have an undefined :code:`endtime`
+        :param str logger: Logger name
+        """
+
+        self._ctx = kwargs.get('context')
+
+        self._logger = logging.getLogger(
+            self.LOGGER if kwargs.get('logger') is None
+            else kwargs.get('logger'))
+        self.logger = (ContextLoggerAdapter(self._logger, {'ctx': self._ctx})
+                       if self._ctx else self._logger)
+
+        self._default_endtime = kwargs.get('default_endtime',
+                                           datetime.datetime.utcnow())
+
+    def _route(self, req, post=True, **kwargs):
+        """
+        Route a request and create a routing table. Routing is performed by
+        means of the routing service provided.
+
+        :param req: Routing service request handler
+        :type req: :py:class:`RoutingRequestHandler`
+        :param bool post: Execute a the request to the routing service via HTTP
+            POST
+
+        :raises NoContent: If no routes are available
+        :raises RequestsError: General exception if request to routing service
+            failed
+        """
+
+        _req = (req.post() if post else req.get())
+
+        routing_table = {}
+        self.logger.info("Fetching routes from %s" % req.url)
+        try:
+            with binary_request(_req) as fd:
+                # parse the routing service's output stream; create a routing
+                # table
+                urlline = None
+                stream_epochs = []
+
+                while True:
+                    line = fd.readline()
+
+                    if not urlline:
+                        urlline = line.strip()
+                    elif not line.strip():
+                        # set up the routing table
+                        if stream_epochs:
+                            routing_table[urlline] = stream_epochs
+
+                        urlline = None
+                        stream_epochs = []
+
+                        if not line:
+                            break
+                    else:
+                        stream_epochs.append(
+                            StreamEpoch.from_snclline(
+                                line, default_endtime=self._default_endtime))
+
+        except NoContent as err:
+            self.logger.warning(err)
+            nodata = int(
+                kwargs.get('nodata',
+                           settings.FDSN_DEFAULT_NO_CONTENT_ERROR_CODE))
+            raise FDSNHTTPError.create(nodata)
+        except RequestsError as err:
+            self.logger.error(err)
+            raise FDSNHTTPError.create(500, service_version=__version__)
+        else:
+            self.logger.debug(
+                'Number of routes received: {}'.format(len(routing_table)))
+
+        return routing_table
+
+    def route(self, req, **kwargs):
+        """
+        Route a request and create a routing table. Routing is performed by
+        means of the routing service provided. Since the
+        :py:meth:`~RequestStrategy._route` returns the number of routes to be
+        processed, :py:class:`~process.RequestProcessor` instances can scale
+        their worker pool sizes appropriately.
+
+        :param req: Routing service request handler
+        :type req: :py:class:`RoutingRequestHandler`
+        :param bool post: Request data by means of HTTP POST.
+
+        :returns: Number of routes
+        :rtype: int
+        """
+
+        raise NotImplementedError
+
+    def request(self, pool, tasks, query_params={}, **kwargs):
+        """
+        Execute requests.
+
+        :param pool: Worker pool tasks are applied to
+        :param dict tasks: Mapping of concrete tasks.
+        :param dict query_params: Q
+
+        :returns: Asynchronous task results
+        """
+
+        raise NotImplementedError
+
+    @staticmethod
+    def _get_task_by_kw(tasks, kw):
+        """
+        Utility method returning the task by keyword.
+        """
+        try:
+            t = tasks[kw]
+        except KeyError as err:
+            raise RequestStrategyError(err)
+        else:
+            return t
+
+
+class GranularRequestStrategy(RequestStrategyBase):
+    """
+    Fetch data using a granular endpoint request strategy.
+    """
+
+    def route(self, req, **kwargs):
+        self._routes = demux_routes(super()._route(req, **kwargs))
+        return len(self._routes)
+
+    def request(self, pool, tasks, query_params={}, **kwargs):
+        """
+        Issue granular endpoint requests.
+        """
+
+        assert hasattr(self, '_routes'), 'Missing routes.'
+
+        default_task = self._get_task_by_kw(tasks, 'default')
+
+        retval = []
+        for route in self._routes:
+            self.logger.debug(
+                'Creating {!r} for {!r} ...'.format(default_task, route))
+            ctx = Context(root_only=True)
+            self._ctx.append(ctx)
+            t = default_task(
+                GranularFdsnRequestHandler(
+                    route.url,
+                    route.streams[0],
+                    query_params=query_params),
+                context=self._ctx,
+                **kwargs)
+            result = pool.apply_async(t)
+            retval.append(result)
+
+        return retval
+
+
+class NetworkBulkRequestStrategy(RequestStrategyBase):
+    """
+    Strategy executing bulk endpoint requests on network code granularity.
+    """
+
+    def route(self, req, **kwargs):
+        """
+        Multiplexed routing i.e. one route contains multiple stream epochs
+        (for a unique network code). Implements bulk request routing based on
+        network codes.
+        """
+        # NOTE(damb): We firstly group routes by network code. Afterwards,
+        # grouped routes are multiplex by network code, again.
+
+        self._routes = _mux_routes(super()._route(req, **kwargs))
+        return len(self._routes)
+
+    def request(self, pool, tasks, query_params={}, **kwargs):
+        """
+        Issue a bulk endpoint request with network granularity.
+        """
+
+        assert hasattr(self, '_routes'), 'Missing routes.'
+
+        default_task = self._get_task_by_kw(tasks, 'default')
+
+        retval = []
+        for net, bulk_routes in self._routes.items():
+            self.logger.debug(
+                'Creating tasks for net={!r} ...'.format(net))
+
+            for bulk_route in bulk_routes:
+                self.logger.debug(
+                    'Creating {!r} for {!r} ...'.format(
+                        default_task, bulk_route))
+
+                ctx = Context(root_only=True)
+                self._ctx.append(ctx)
+
+                t = default_task(
+                    BulkFdsnRequestHandler(
+                        bulk_route.url,
+                        stream_epochs=bulk_route.streams,
+                        query_params=query_params),
+                    context=ctx,
+                    **kwargs)
+                result = pool.apply_async(t)
+                retval.append(result)
+
+        return retval
+
+
+class AdaptiveNetworkBulkRequestStrategy(NetworkBulkRequestStrategy):
+    """
+    Adaptive request strategy executing bulk endpoint requests on network code
+    granularity. For distributed physical networks a executing endpoint
+    requests is delegated to a secondary task.
+    """
+
+    def route(self, req, **kwargs):
+        """
+        Demultiplex routes for distributed physical networks.
+        """
+        self._routes = {}
+
+        for net, _routes in _mux_routes(
+                super()._route(req, **kwargs)).items():
+            if len(_routes) > 1:
+                # demux routes
+                self._routes[net] = [utils.Route(route.url, streams=[se])
+                                     for route in _routes
+                                     for se in route.streams]
+            else:
+                self._routes[net] = _routes
+
+        return len(self._routes)
+
+    def request(self, pool, tasks, query_params={}, **kwargs):
+        """
+        Issue a bulk endpoint request with network code granularity. For
+        distributed physical networks a request execution is delegated to a
+        secondary-level task.
+        """
+        assert hasattr(self, '_routes'), 'Missing routes.'
+
+        default_task = self._get_task_by_kw(tasks, 'default')
+        combining_task = self._get_task_by_kw(tasks, 'combining')
+
+        retval = []
+
+        for net, routes in self._routes.items():
+            # create subcontext
+            ctx = Context(root_only=True, payload=net)
+            self._ctx.append(ctx)
+
+            if len(routes) == 1:
+                self.logger.debug(
+                    'Creating {!r} for net={!r} ...'.format(
+                        default_task, net))
+                t = default_task(
+                    BulkFdsnRequestHandler(
+                        routes[0].url, stream_epochs=routes[0].streams,
+                        query_params=query_params),
+                    context=ctx,
+                    name=net,
+                    **kwargs)
+
+            elif len(routes) > 1:
+                self.logger.debug(
+                    'Creating {!r} for net={!r} ...'.format(
+                        combining_task, net))
+                t = combining_task(
+                    routes, query_params, name=net, context=ctx, **kwargs)
+            else:
+                raise RoutingError('Missing routes.')
+
+            result = pool.apply_async(t)
+            retval.append(result)
+
+        return retval
+
+
+class NetworkCombiningRequestStrategy(RequestStrategyBase):
+    """
+    Request strategy implementing data merging on a network level granularity.
+    """
+
+    def route(self, req, **kwargs):
+        self._routes = group_routes_by(super()._route(req, **kwargs),
+                                       key='network')
+
+        return len(self._routes)
+
+    def request(self, pool, tasks, query_params={}, **kwargs):
+        """
+        Issue combining tasks. Issuing endpoint requests is delegated to those
+        tasks.
+        """
+        assert hasattr(self, '_routes'), 'Missing routes.'
+
+        combining_task = self._get_task_by_kw(tasks, 'combining')
+
+        retval = []
+        for net, routes in self._routes.items():
+            ctx = Context(root_only=True, payload=net)
+            self._ctx.append(ctx)
+            self.logger.debug(
+                'Creating {!r} for net={!r} ...'.format(combining_task, net))
+            t = combining_task(
+                routes, query_params, name=net, context=ctx, **kwargs)
+            result = pool.apply_async(t)
+            retval.append(result)
+
+        return retval

--- a/eidangservices/federator/server/strategy.py
+++ b/eidangservices/federator/server/strategy.py
@@ -265,7 +265,7 @@ class NetworkBulkRequestStrategy(RequestStrategyBase):
         network codes.
         """
         # NOTE(damb): We firstly group routes by network code. Afterwards,
-        # grouped routes are multiplex by network code, again.
+        # grouped routes are multiplexed by network code, again.
 
         self._routes = _mux_routes(super()._route(req, **kwargs))
         return len(self._routes)

--- a/eidangservices/federator/server/task.py
+++ b/eidangservices/federator/server/task.py
@@ -690,9 +690,9 @@ class RawSplitAndAlignTask(SplitAndAlignTask):
             except (OSError, IOError, ValueError):
                 pass
 
-            req = (self._request_handler.get()
+            req = (request_handler.get()
                    if self._http_method == 'GET' else
-                   self._request_handler.post())
+                   request_handler.post())
 
             self.logger.debug(
                 'Downloading (url={}, stream_epochs={}, method={!r}) '
@@ -767,9 +767,9 @@ class WFCatalogSplitAndAlignTask(SplitAndAlignTask):
             request_handler = GranularFdsnRequestHandler(
                 self._url, stream_epoch, query_params=self.query_params)
 
-            req = (self._request_handler.get()
+            req = (request_handler.get()
                    if self._http_method == 'GET' else
-                   self._request_handler.post())
+                   request_handler.post())
 
             self.logger.debug(
                 'Downloading (url={}, stream_epochs={}, method={!r}) '

--- a/eidangservices/federator/server/task.py
+++ b/eidangservices/federator/server/task.py
@@ -132,7 +132,7 @@ class TaskBase:
     """
     Base class for tasks.
 
-    :param str logger: Name of the logger to be aqucired
+    :param str logger: Name of the logger to be acquired
     :param keep_tempfiles: Flag how temporary files should be treated
     :type keep_tempfiles: :py:class:`KeepTempfiles`
     """

--- a/eidangservices/federator/server/task.py
+++ b/eidangservices/federator/server/task.py
@@ -14,7 +14,6 @@ from multiprocessing.pool import ThreadPool
 
 import ijson
 
-from flask import current_app
 from lxml import etree
 
 from eidangservices import settings
@@ -230,7 +229,7 @@ class CombinerTask(TaskBase):
 
         self._num_workers = min(
             len(routes),
-            kwargs.get('max_threads', self.MAX_THREADS_DOWNLOADING))
+            kwargs.get('pool_size', self.MAX_THREADS_DOWNLOADING))
         self._pool = None
 
         self._results = []
@@ -307,6 +306,8 @@ class StationXMLNetworkCombinerTask(CombinerTask):
 
     LOGGER = 'flask.app.federator.task_combiner_stationxml'
 
+    POOL_SIZE = 5
+
     NETWORK_TAG = settings.STATIONXML_ELEMENT_NETWORK
     STATION_TAG = settings.STATIONXML_ELEMENT_STATION
     CHANNEL_TAG = settings.STATIONXML_ELEMENT_CHANNEL
@@ -326,10 +327,6 @@ class StationXMLNetworkCombinerTask(CombinerTask):
 
         self._network_elements = []
         self.path_tempfile = None
-
-    @property
-    def MAX_THREADS_DOWNLOADING(self):
-        return current_app.config['FED_THREAD_CONFIG']['fdsnws-station-xml']
 
     def _clean(self, result):
         self.logger.debug(

--- a/eidangservices/federator/server/task.py
+++ b/eidangservices/federator/server/task.py
@@ -311,6 +311,8 @@ class StationXMLNetworkCombinerTask(CombinerTask):
     def __init__(self, routes, query_params, **kwargs):
 
         nets = set([se.network for route in routes for se in route.streams])
+
+        # TODO(damb): Use assert instead
         if len(nets) != 1:
             raise ValueError(
                 'Routes must belong exclusively to a single '
@@ -318,8 +320,8 @@ class StationXMLNetworkCombinerTask(CombinerTask):
 
         super().__init__(routes, query_params, logger=self.LOGGER, **kwargs)
         self._level = self.query_params.get('level', 'station')
-        self._network_elements = []
 
+        self._network_elements = []
         self.path_tempfile = None
 
     @property
@@ -841,12 +843,14 @@ class RawDownloadTask(TaskBase):
     def __init__(self, request_handler, **kwargs):
         super().__init__(self.LOGGER, **kwargs)
         self._request_handler = request_handler
+        # TODO TODO TODO
         self.chunk_size = (self.CHUNK_SIZE
                            if kwargs.get('chunk_size') is None
                            else kwargs.get('chunk_size'))
         self.decode_unicode = (self.DECODE_UNICODE
                                if kwargs.get('decode_unicode') is None
                                else kwargs.get('decode_unicode'))
+        self._http_get = kwargs.get('http_get', False)
 
         self.path_tempfile = get_temp_filepath()
         self._size = 0
@@ -860,10 +864,12 @@ class RawDownloadTask(TaskBase):
                    self._request_handler.stream_epochs,
                    self.path_tempfile))
 
+        req = (self._request_handler.get()
+               if self._http_get else self._request_handler.post())
         try:
             with open(self.path_tempfile, 'wb') as ofd:
                 for chunk in stream_request(
-                        self._request_handler.post(),
+                        req,
                         chunk_size=self.chunk_size,
                         method='raw',
                         decode_unicode=self.decode_unicode):

--- a/eidangservices/federator/server/task.py
+++ b/eidangservices/federator/server/task.py
@@ -855,12 +855,9 @@ class RawDownloadTask(TaskBase):
         super().__init__(self.LOGGER, **kwargs)
         self._request_handler = request_handler
         # TODO TODO TODO
-        self.chunk_size = (self.CHUNK_SIZE
-                           if kwargs.get('chunk_size') is None
-                           else kwargs.get('chunk_size'))
-        self.decode_unicode = (self.DECODE_UNICODE
-                               if kwargs.get('decode_unicode') is None
-                               else kwargs.get('decode_unicode'))
+        self.chunk_size = kwargs.get('chunk_size', self.CHUNK_SIZE)
+        self.decode_unicode = kwargs.get('decode_unicode', self.DECODE_UNICODE)
+
         self._http_get = kwargs.get('http_get', False)
 
         self.path_tempfile = get_temp_filepath()
@@ -1004,8 +1001,8 @@ class StationXMLDownloadTask(RawDownloadTask):
     def __init__(self, request_handler, **kwargs):
         super().__init__(request_handler, **kwargs)
         self.network_tag = kwargs.get('network_tag', self.NETWORK_TAG)
-        self.name = ('{}-{}'.format(type(self).__name__, kwargs.get('name')) if
-                     kwargs.get('name') else type(self).__name__)
+        self.name = '{}-{}'.format(type(self).__name__,
+                                   kwargs.get('name', 'UNKOWN'))
 
     @catch_default_task_exception
     @with_ctx_guard

--- a/eidangservices/settings.py
+++ b/eidangservices/settings.py
@@ -569,6 +569,9 @@ EIDA_FEDERATOR_THREAD_CONFIG = {
 EIDA_FEDERATOR_SHARE_DIR = FDSN_WADL_DIR
 EIDA_FEDERATOR_APP_SHARE = os.path.join(APP_ROOT, EIDA_FEDERATOR_SERVICE_ID,
                                         EIDA_FEDERATOR_SHARE_DIR)
+
+# default HTTP request method when issuing requests to endpoint datacenters
+EIDA_FEDERATOR_DEFAULT_HTTP_METHOD = 'POST'
 EIDA_FEDERATOR_HIDDEN_CTX_LOCKS = True
 
 # -----------------------------------------------------------------------------

--- a/eidangservices/settings.py
+++ b/eidangservices/settings.py
@@ -560,18 +560,43 @@ EIDA_FEDERATOR_THREADS_STATION_TEXT = 10
 # number of federator-WFCatalog download threads
 EIDA_FEDERATOR_THREADS_WFCATALOG = 10
 
-EIDA_FEDERATOR_THREAD_CONFIG = {
-    "fdsnws-dataselect": EIDA_FEDERATOR_THREADS_DATASELECT,
-    "fdsnws-station-xml": EIDA_FEDERATOR_THREADS_STATION_XML,
-    "fdsnws-station-text": EIDA_FEDERATOR_THREADS_STATION_TEXT,
-    "eidaws-wfcatalog": EIDA_FEDERATOR_THREADS_WFCATALOG}
+# default HTTP request method when issuing requests to endpoint datacenters
+EIDA_FEDERATOR_DEFAULT_HTTP_METHOD = 'POST'
+
+EIDA_FEDERATOR_RESOURCE_CONFIG = {
+    "fdsnws-dataselect": {
+        'num_threads': EIDA_FEDERATOR_THREADS_DATASELECT,
+        'request_strategy': 'granular',
+        'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
+    },
+    "fdsnws-station-xml": {
+        'num_threads': EIDA_FEDERATOR_THREADS_STATION_XML,
+        'request_strategy': 'adaptive-bulk',
+        'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
+    },
+    "fdsnws-station-text": {
+        'num_threads': EIDA_FEDERATOR_THREADS_STATION_TEXT,
+        'request_strategy': 'bulk',
+        'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
+    },
+    "eidaws-wfcatalog": {
+        'num_threads': EIDA_FEDERATOR_THREADS_WFCATALOG,
+        'request_strategy': 'granular',
+        'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
+    }
+}
+
+EIDA_FEDERATOR_REQUEST_STRATEGIES = (
+    'granular',
+    'bulk',
+    'adaptive-bulk',
+    'combining')
+EIDA_FEDERATOR_REQUEST_METHODS = ('POST', 'GET')
 
 EIDA_FEDERATOR_SHARE_DIR = FDSN_WADL_DIR
 EIDA_FEDERATOR_APP_SHARE = os.path.join(APP_ROOT, EIDA_FEDERATOR_SERVICE_ID,
                                         EIDA_FEDERATOR_SHARE_DIR)
 
-# default HTTP request method when issuing requests to endpoint datacenters
-EIDA_FEDERATOR_DEFAULT_HTTP_METHOD = 'POST'
 EIDA_FEDERATOR_HIDDEN_CTX_LOCKS = True
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
This PR is a prerequisite for #75.

**Features and Changes**:

- Allow request processors to be configured with configurable request strategies.
- Request strategies can be used together with one of HTTP POST|GET (with respect to endpoint requests). 
- Bulk request strategy is currently HTTP POST, only.
- Both request strategies and request methods are configurable at the CLI / service configuration file.
- Remove `-t|--entpoint-threads` CLI parameter; configuring the number of endpoint threads is now part of the `--resource-config` CLI configuration parameter.

References and closes: #77 