### PR TITLE
[WIP] Cache /fdsnws/station requests

### DIFF
--- a/config/eidangws_config
+++ b/config/eidangws_config
@@ -100,6 +100,12 @@
 # proxy_netloc = '//[user[:password]@]host[:port]
 #
 # ----
+# Enable cache control headers and configure the max-age property for
+# statically created content (i.e. fdsnws-station).
+#
+# cache_control_max_age = 0
+#
+# ----
 # Set the path to a logging configuration file. For information on howto setup
 # a logging configuration file visit the official Python documentation:
 # https://docs.python.org/3/library/logging.config.html#configuration-file-format

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -22,6 +22,11 @@ services:
         target: /var/tmp
         volume:
           nocopy: false
+      - type: volume
+        source: federator_cache
+        target: /var/cache/apache2/mod_cache_disk
+        volume:
+          nocopy: false
     ports:
       - "8080:80"
 
@@ -68,4 +73,5 @@ volumes:
   mediatorws_log:
   mediatorws_tmp:
   stationlite_pgdata:
+  federator_cache:
   federator_cache_proxy:

--- a/docker/prod/federator/Dockerfile
+++ b/docker/prod/federator/Dockerfile
@@ -79,6 +79,7 @@ RUN cp -v db/stationlite.db.empty db/stationlite.db
 RUN chmod +r /var/www/mediatorws/config/eidangws_config /var/www/mediatorws/apache2/*.wsgi
 
 # Enable the supplied WSGI modules
+RUN a2enmod cache_disk
 RUN a2dissite 000-default.conf
 RUN a2ensite federator.conf
 

--- a/docker/prod/federator/eidangws_config
+++ b/docker/prod/federator/eidangws_config
@@ -111,6 +111,15 @@ tmpdir=/var/tmp
 proxy_netloc = //federator-proxy
 #
 # ----
+# Enable cache control headers and configure the max-age property for
+# statically created content (i.e. fdsnws-station).
+#
+# cache_control_max_age = 0
+#
+# Cache for up to 12 hours.
+cache_control_max_age = 43200
+#
+# ----
 # Set the path to a logging configuration file. For information on howto setup
 # a logging configuration file visit the official Python documentation:
 # https://docs.python.org/3/library/logging.config.html#configuration-file-format

--- a/docker/prod/federator/federator.conf
+++ b/docker/prod/federator/federator.conf
@@ -4,6 +4,9 @@
 
         DocumentRoot /var/www/html
 
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
         <Directory /var/www/html>
                 Order allow,deny
                 Allow from all

--- a/docker/prod/federator/federator.conf
+++ b/docker/prod/federator/federator.conf
@@ -38,9 +38,32 @@
         WSGIScriptAlias /fdsnws /var/www/mediatorws/apache2/federator.wsgi/fdsnws
         WSGIScriptAlias /eidaws/wfcatalog /var/www/mediatorws/apache2/federator.wsgi/eidaws/wfcatalog
 
-        <Location ~ "/(fdsnws|eidaws/wfcatalog)">
+        CacheLock               on
+        CacheLockPath           /tmp/mod_cache-noa-lock
+        CacheLockMaxAge         30
+
+        CacheIgnoreNoLastMod    on
+        CacheStoreExpired       on
+
+        # Cache regex e.g. via LocationMatch (normal handler only)
+        CacheQuickHandler       off
+
+        # Cache fdsnws-station
+        <LocationMatch "^/fdsnws/station/">
+          # XXX(damb): Caching applies only to GET requests.
+          CacheEnable disk
+          CacheHeader           on
+          CacheDetailHeader     on
+
+          # Cache for up 12 hours
+          CacheMaxExpire 43200
+          # On cache miss, forward the request to mod_wsgi
+          WSGIProcessGroup federator
+        </LocationMatch>
+
+        <LocationMatch "^/(fdsnws/dataselect|eidaws/wfcatalog)">
             WSGIProcessGroup federator
-        </Location>
+        </LocationMatch>
 
         <Directory "/var/www/mediatorws/eidangservices/federator">
             WSGIScriptReloading On

--- a/docker/prod/proxy/httpd.conf
+++ b/docker/prod/proxy/httpd.conf
@@ -39,7 +39,7 @@ Listen 8002
     CacheDetailHeader     on
     CacheIgnoreNoLastMod  on
 
-    # Cache for up 12 hours 
+    # Cache for up 12 hours
     CacheMaxExpire 43200
     # On cache miss, forward the request to the header processor
     ProxyPass "http://localhost:8002/$1/fdsnws/station/$2" timeout=30

--- a/docker/prod/proxy/httpd.conf
+++ b/docker/prod/proxy/httpd.conf
@@ -39,8 +39,8 @@ Listen 8002
     CacheDetailHeader     on
     CacheIgnoreNoLastMod  on
 
-    # Cache for up 60 to minutes
-    CacheMaxExpire 3600
+    # Cache for up 12 hours 
+    CacheMaxExpire 43200
     # On cache miss, forward the request to the header processor
     ProxyPass "http://localhost:8002/$1/fdsnws/station/$2" timeout=30
     ProxyPassReverse "http://localhost:8002/$1/fdsnws/station/$2"
@@ -80,13 +80,13 @@ Listen 8002
   # change it if it's 0.
   Header merge Cache-Control "max-age=bidon"
   # Case when we have: Cache-Control max-age=.., ....
-  Header edit  Cache-Control "^(.*)max-age=(.*)max-age=bidon, (.*)$" $1max-age=1800$3
+  Header edit  Cache-Control "^(.*)max-age=(.*)max-age=bidon, (.*)$" $1max-age=43200$3
   # Case when we have: Cache-Control yyy=bidon, max-age=.."
-  Header edit  Cache-Control "^(.*)max-age=(.*), max-age=bidon$" $1max-age=1800
+  Header edit  Cache-Control "^(.*)max-age=(.*), max-age=bidon$" $1max-age=43200
   # Now Replace the value if there was not a max-age, set to 30mn
-  Header edit  Cache-Control "max-age=bidon" "max-age=1800"
+  Header edit  Cache-Control "max-age=bidon" "max-age=43200"
   # Now Replace the value if there was a max-age=0, set to 30mn
-  Header edit  Cache-Control "max-age=0" "max-age=1800"
+  Header edit  Cache-Control "max-age=0" "max-age=43200"
 
   # XXX(damb): Modifying Cache-Control headers violates RFC2616
   # (https://tools.ietf.org/html/rfc2616#section-14.9).
@@ -99,7 +99,7 @@ Listen 8002
   Header edit Cache-Control "post-check=0, " ""
   Header edit Cache-Control "pre-check=0, " ""
   Header edit Cache-Control "must-revalidate, " ""
-  Header merge Cache-Control "s-maxage=1800"
+  Header merge Cache-Control "s-maxage=43200"
 
   <LocationMatch "^/(.*)">
     ProxyPass "http://$1"

--- a/eidangservices/federator/server/__init__.py
+++ b/eidangservices/federator/server/__init__.py
@@ -57,6 +57,15 @@ def create_app(config_dict={}, service_version=__version__):
         g.ctx = Context(ctx=g.request_id)
         g.ctx.acquire()
 
+    @app.after_request
+    def configure_cache_control_headers(response):
+        if (config_dict['FED_CACHE_CONTROL_MAX_AGE'] > 0 and
+                'Cache-Control' not in response.headers):
+            response.cache_control.public = True
+            response.cache_control.max_age = \
+                config_dict['FED_CACHE_CONTROL_MAX_AGE']
+        return response
+
     @app.teardown_request
     def teardown_request(exception):
         try:

--- a/eidangservices/federator/server/__init__.py
+++ b/eidangservices/federator/server/__init__.py
@@ -59,11 +59,11 @@ def create_app(config_dict={}, service_version=__version__):
 
     @app.after_request
     def configure_cache_control_headers(response):
-        if (config_dict['FED_CACHE_CONTROL_MAX_AGE'] > 0 and
-                'Cache-Control' not in response.headers):
+        max_age = config_dict['FED_CACHE_CONTROL_MAX_AGE']
+        if (max_age > 0 and 'Cache-Control' not in response.headers):
             response.cache_control.public = True
-            response.cache_control.max_age = \
-                config_dict['FED_CACHE_CONTROL_MAX_AGE']
+            response.cache_control.max_age = max_age
+
         return response
 
     @app.teardown_request

--- a/eidangservices/federator/server/app.py
+++ b/eidangservices/federator/server/app.py
@@ -90,13 +90,13 @@ def keeptempfile_config(arg):
     return getattr(KeepTempfiles, arg.upper().replace('-', '_'))
 
 
-def _pos_number(arg, vtype):
+def _pos_number(arg, vtype, strict=True):
     try:
         arg = vtype(arg)
     except ValueError as err:
         raise argparse.ArgumentTypeError(err)
 
-    if arg <= 0:
+    if arg < 0 or (strict and arg <= 0):
         raise argparse.ArgumentTypeError(
             'Only positive numbers allowed.')
     return arg
@@ -108,6 +108,10 @@ def pos_int(arg):
 
 def pos_float(arg):
     return _pos_number(arg, float)
+
+
+def pos_int_or_null(arg):
+    return _pos_number(arg, int, strict=False)
 
 
 def percent(arg):
@@ -232,6 +236,13 @@ class FederatorWebserviceBase(App):
                                   '(JSON syntax). Note, that bulk request '
                                   'strategies force the request method to '
                                   '"POST". (default: %(default)s)'))
+        parser.add_argument('--cache-control-max-age', type=pos_int_or_null,
+                            metavar='SECONDS', dest='cache_control_max_age',
+                            default=0,
+                            help=('Enable cache control headers and configure '
+                                  'the max-age property for statically '
+                                  'created content (i.e. fdsnws-station). '
+                                  '(default: %(default)s)'))
         parser.add_argument('--tmpdir', type=str, default='',
                             help='directory for temp files')
         parser.add_argument('--keep-tempfiles', dest='keep_tempfiles',
@@ -350,6 +361,7 @@ class FederatorWebserviceBase(App):
             FED_CRETRY_BUDGET_TTL=self.args.cretry_budget_ttl,
             FED_CRETRY_BUDGET_ERATIO=self.args.cretry_budget_eratio,
             FED_NETLOC_PROXY=self.args.proxy_netloc,
+            FED_CACHE_CONTROL_MAX_AGE=self.args.cache_control_max_age,
             TMPDIR=tempfile.gettempdir())
 
         app = create_app(config_dict=app_config)

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -75,6 +75,8 @@ class RequestProcessor(ClientRetryBudgetMixin):
     # MAX_TASKS_PER_CHILD = 4
     TIMEOUT_STREAMING = settings.EIDA_FEDERATOR_STREAMING_TIMEOUT
 
+    RESPONSE_HEADERS = {}
+
     def __init__(self, mimetype, query_params={}, stream_epochs=[], **kwargs):
         """
         :param str mimetype: The response's mimetype
@@ -197,7 +199,8 @@ class RequestProcessor(ClientRetryBudgetMixin):
         self._wait()
 
         resp = Response(stream_with_context(self), mimetype=self.mimetype,
-                        content_type=self.content_type)
+                        content_type=self.content_type,
+                        headers=self.RESPONSE_HEADERS)
 
         resp.call_on_close(self._call_on_close)
 
@@ -357,6 +360,8 @@ class RawRequestProcessor(RequestProcessor):
 
     ALLOWED_STRATEGIES = ('granular', 'bulk')
     DEFAULT_DEFAULT_REQUEST_STRATEGY = 'granular'
+
+    RESPONSE_HEADERS = {'Cache-Control': 'no-store'}
 
     CHUNK_SIZE = 1024
 
@@ -813,6 +818,8 @@ class WFCatalogRequestProcessor(RequestProcessor):
 
     ALLOWED_STRATEGIES = ('granular', 'bulk')
     DEFAULT_REQUEST_STRATEGY = 'granular'
+
+    RESPONSE_HEADERS = {'Cache-Control': 'no-store'}
 
     CHUNK_SIZE = 1024
 


### PR DESCRIPTION
**Features and Changes**:
- Use Apache2's `mod_cache_disk` in order to cache `/fdsnws/station` HTTP GET requests
- Cache for up to 24 hours (12 hours + 12 hours)
- Cache control headers are configured by the `eida-federator` WSGI application

---
**Disadvantages** of this approach:
- Works for HTTP GET requests only. I.e. HTTP POST requests are not cached at all.
- Proxies may force circumventing the cache
- The [FDSNWS specs 1.2](https://www.fdsn.org/webservices/FDSN-WS-Specifications-1.2.pdf) allow for query parameters to be unordered. Clients requesting data once with e.g.
```
curl -v "http://localhost:8080/fdsnws/station/1/query?net=CH&sta=*&level=station&format=xml&start=2019-01-01"
```
and

```
curl -v "http://localhost:8080/fdsnws/station/1/query?net=CH&sta=*&level=station&start=2019-01-01&format=xml"
```
or even

```
curl -v "http://localhost:8080/fdsnws/station/1/query?net=CH,GR&sta=*&level=station&start=2019-01-01&format=xml"
```
and

```
curl -v "http://localhost:8080/fdsnws/station/1/query?net=GR,CH&sta=*&level=station&start=2019-01-01&format=xml"
```
can force cache misses. Also aliases are not taken into consideration (e.g. queries with `net` and `network` are treated differently).

- The approach does not implement a distributed cache which may be shared by several Apache2 instances. Though, Apache2 does provide [mod_cache_socache](https://httpd.apache.org/docs/2.4/mod/mod_cache_socache.html) for distributed caching using e.g. a [Memcached](https://memcached.org/) backend.

As a consequence of the disadvantages listed above, the application IMO should handle the cache internally. Note, that the current docker production setup comes along with a [redis]( https://redis.io/) server anyway which could be used for this purpose.