### PR TITLE
Frontend caching

### DIFF
--- a/config/eidangws_config
+++ b/config/eidangws_config
@@ -82,7 +82,6 @@
 # "CACHE_TYPE" to "fs". A file system cache provides the following
 # configuration parameters ("CACHE_KWARGS" attribute):
 #   - "cache_dir": Location of the file system cache
-#   - "mode": Mode of cache files
 #   - "default_timeout": TTL
 #   - "threshold": Maximum number of items the cache stores before it starts
 #                 deleting some. A value of 0 idicates no threshold.

--- a/config/eidangws_config
+++ b/config/eidangws_config
@@ -71,6 +71,28 @@
 # scales squared.
 #
 # ----
+# Configure eida-federator frontend caching backend. The default configuration
+# is:
+#
+# cache_config = '{
+#   "CACHE_TYPE": "null",
+#   "CACHE_KWARGS": {}}'
+#
+# Two caching backends are configurable. For local file caching set
+# "CACHE_TYPE" to "fs". A file system cache provides the following
+# configuration parameters ("CACHE_KWARGS" attribute):
+#   - "cache_dir": Location of the file system cache
+#   - "mode": Mode of cache files
+#   - "default_timeout": TTL
+#   - "threshold": Maximum number of items the cache stores before it starts
+#                 deleting some. A value of 0 idicates no threshold.
+#
+# For distributed caching a Redis backend is provided (set "CACHE_TYPE" to
+# "redis"). A Redis cache provide sthe following configuration parameters:
+#   - "url": URL of Redis datastore
+#   - "default_timeout": TTL
+#
+# ----
 # Per client retry-budget cut-off error ratio in percent. Requests to remote
 # datacenters (DC) are dropped above this value. The default configuration is:
 # 1.0

--- a/docker/prod/docker-compose.yml
+++ b/docker/prod/docker-compose.yml
@@ -22,6 +22,11 @@ services:
         target: /var/tmp
         volume:
           nocopy: false
+      - type: volume
+        source: federator_cache
+        target: /var/cache/eida-federator
+        volume:
+          nocopy: false
     ports:
       - "8080:80"
 
@@ -68,4 +73,5 @@ volumes:
   mediatorws_log:
   mediatorws_tmp:
   stationlite_pgdata:
+  federator_cache:
   federator_cache_proxy:

--- a/docker/prod/federator/Dockerfile
+++ b/docker/prod/federator/Dockerfile
@@ -92,6 +92,7 @@ RUN (crontab -l ; echo "0 4 * * * source /var/www/mediatorws/docker/prod/federat
 
 RUN mkdir -p /var/www/mediatorws/log && chown www-data:www-data /var/www/mediatorws/log
 RUN mkdir -p /var/tmp/ && chown www-data:www-data /var/tmp/
+RUN mkdir -p /var/cache/eida-federator && chown www-data:www-data /var/cache
 
 # Add the logging configuration
 COPY fed-logging.conf /var/www/mediatorws/config/fed-logging.conf

--- a/docker/prod/federator/Dockerfile
+++ b/docker/prod/federator/Dockerfile
@@ -92,7 +92,7 @@ RUN (crontab -l ; echo "0 4 * * * source /var/www/mediatorws/docker/prod/federat
 
 RUN mkdir -p /var/www/mediatorws/log && chown www-data:www-data /var/www/mediatorws/log
 RUN mkdir -p /var/tmp/ && chown www-data:www-data /var/tmp/
-RUN mkdir -p /var/cache/eida-federator && chown www-data:www-data /var/cache
+RUN mkdir -p /var/cache/eida-federator && chown www-data:www-data /var/cache/eida-federator
 
 # Add the logging configuration
 COPY fed-logging.conf /var/www/mediatorws/config/fed-logging.conf

--- a/docker/prod/federator/eidangws_config
+++ b/docker/prod/federator/eidangws_config
@@ -100,7 +100,6 @@ cache_config = {
 # "CACHE_TYPE" to "fs". A file system cache provides the following
 # configuration parameters ("CACHE_KWARGS" attribute):
 #   - "cache_dir": Location of the file system cache
-#   - "mode": Mode of cache files
 #   - "default_timeout": TTL
 #   - "threshold": Maximum number of items the cache stores before it starts
 #                 deleting some. A value of 0 idicates no threshold.

--- a/docker/prod/federator/eidangws_config
+++ b/docker/prod/federator/eidangws_config
@@ -94,7 +94,7 @@ cache_config = {
   "CACHE_TYPE": "fs",
   "CACHE_KWARGS": {
     "cache_dir": "/var/cache/eida-federator",
-    "default_timeout": 43200, }}
+    "default_timeout": 43200}}
 #
 # Two caching backends are configurable. For local file caching set
 # "CACHE_TYPE" to "fs". A file system cache provides the following

--- a/docker/prod/federator/eidangws_config
+++ b/docker/prod/federator/eidangws_config
@@ -83,6 +83,34 @@ resource_config = {
 # scales squared.
 #
 # ----
+# Configure eida-federator frontend caching backend. The default configuration
+# is:
+#
+# cache_config = '{
+#   "CACHE_TYPE": "null",
+#   "CACHE_KWARGS": {}}'
+#
+cache_config = {
+  "CACHE_TYPE": "fs",
+  "CACHE_KWARGS": {
+    "cache_dir": "/var/cache/eida-federator",
+    "default_timeout": 43200, }}
+#
+# Two caching backends are configurable. For local file caching set
+# "CACHE_TYPE" to "fs". A file system cache provides the following
+# configuration parameters ("CACHE_KWARGS" attribute):
+#   - "cache_dir": Location of the file system cache
+#   - "mode": Mode of cache files
+#   - "default_timeout": TTL
+#   - "threshold": Maximum number of items the cache stores before it starts
+#                 deleting some. A value of 0 idicates no threshold.
+#
+# For distributed caching a Redis backend is provided (set "CACHE_TYPE" to
+# "redis"). A Redis cache provide sthe following configuration parameters:
+#   - "url": URL of Redis datastore
+#   - "default_timeout": TTL
+#
+# ----
 # Per client retry-budget cut-off error ratio in percent. Requests to remote
 # datacenters (DC) are dropped above this value. The default configuration is:
 # 1.0

--- a/eidangservices/federator/server/__init__.py
+++ b/eidangservices/federator/server/__init__.py
@@ -12,6 +12,7 @@ from flask_redis import FlaskRedis
 from eidangservices import settings
 from eidangservices.federator import __version__
 from eidangservices.federator.server.stats import ResponseCodeStats
+from eidangservices.federator.server.cache import Cache
 from eidangservices.utils import httperrors
 from eidangservices.utils.error import Error
 from eidangservices.utils.fdsnws import (register_parser_errorhandler,
@@ -21,6 +22,8 @@ from eidangservices.utils.fdsnws import (register_parser_errorhandler,
 redis_client = FlaskRedis()
 
 response_code_stats = ResponseCodeStats(redis=redis_client)
+
+cache = Cache()
 
 
 def create_app(config_dict={}, service_version=__version__):
@@ -45,6 +48,8 @@ def create_app(config_dict={}, service_version=__version__):
         'window_size': config_dict['FED_CRETRY_BUDGET_WINDOW_SIZE'],
         'ttl': config_dict['FED_CRETRY_BUDGET_TTL'],
     }
+    # configure cache
+    cache.init_cache(config=config_dict)
 
     # app.config['PROFILE'] = True
     # app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[10])

--- a/eidangservices/federator/server/app.py
+++ b/eidangservices/federator/server/app.py
@@ -115,10 +115,14 @@ def cache_config(arg):
     if difference:
         return argparse.ArgumentTypeError('Invalid key: {!r}'.format())
 
-    cache_type = config_dict['CACHE_TYPE']
-    if cache_type not in Cache.CACHE_MAP:
-        raise argparse.ArgumentTypeError(
-            'Invalid cache type: {!r}'.format(cache_type))
+    try:
+        cache_type = config_dict['CACHE_TYPE']
+    except KeyError:
+        raise argparse.ArgumentTypeError('Missing cache type.')
+    else:
+        if cache_type not in Cache.CACHE_MAP:
+            raise argparse.ArgumentTypeError(
+                'Invalid cache type: {!r}'.format(cache_type))
 
     config_dict.setdefault('CACHE_KWARGS', {})
     allowed_args = set(inspect.getfullargspec(

--- a/eidangservices/federator/server/app.py
+++ b/eidangservices/federator/server/app.py
@@ -100,6 +100,17 @@ def resource_config(config_dict):
     return retval
 
 
+def cache_config(arg):
+    # TODO(damb): Validate parameters
+    try:
+        config_dict = json.loads(arg)
+    except Exception as err:
+        raise argparse.ArgumentTypeError(
+            'Invalid cache configuration dictionary syntax ({}).'.format(err))
+    else:
+        return config_dict
+
+
 def keeptempfile_config(arg):
     """
     Populate the corresponding :code:`enum` value from the CLI configuration.
@@ -219,6 +230,11 @@ class FederatorWebserviceBase(App):
                                   '"POST". (default: %(default)s)'))
         parser.add_argument('--tmpdir', type=str, default='',
                             help='directory for temp files')
+        parser.add_argument('--cache-config', type=cache_config,
+                            dest='cache_config', metavar='DICT',
+                            default=settings.EIDA_FEDERATOR_CACHE_CONFIG,
+                            help=('Cache configuration dictionary '
+                                  '(JSON syntax) (default: %(default)s'))
         parser.add_argument('--keep-tempfiles', dest='keep_tempfiles',
                             choices=sorted(
                                 [str(c).replace('KeepTempfiles.', '').lower().
@@ -335,6 +351,9 @@ class FederatorWebserviceBase(App):
             FED_CRETRY_BUDGET_TTL=self.args.cretry_budget_ttl,
             FED_CRETRY_BUDGET_ERATIO=self.args.cretry_budget_eratio,
             TMPDIR=tempfile.gettempdir())
+
+        if self.args.cache_config:
+            app_config.update(self.args.cache_config)
 
         app = create_app(config_dict=app_config)
         api.init_app(app)

--- a/eidangservices/federator/server/app.py
+++ b/eidangservices/federator/server/app.py
@@ -103,7 +103,6 @@ def resource_config(config_dict):
 
 
 def cache_config(arg):
-    # TODO(damb): Validate parameters
     try:
         config_dict = json.loads(arg)
     except Exception as err:

--- a/eidangservices/federator/server/app.py
+++ b/eidangservices/federator/server/app.py
@@ -103,6 +103,9 @@ def resource_config(config_dict):
 
 
 def cache_config(arg):
+    # XXX(damb): Exclude for all CACHE_TYPEs
+    INVALID_CACHE_ARGS = set(['mode', ])
+
     try:
         config_dict = json.loads(arg)
     except Exception as err:
@@ -126,7 +129,7 @@ def cache_config(arg):
 
     config_dict.setdefault('CACHE_KWARGS', {})
     allowed_args = set(inspect.getfullargspec(
-        Cache.CACHE_MAP[cache_type]).args[1:])
+        Cache.CACHE_MAP[cache_type]).args[1:]) - INVALID_CACHE_ARGS
     difference = set(config_dict['CACHE_KWARGS']) - allowed_args
 
     if difference:

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -30,52 +30,6 @@ class CacheError(ErrorWithTraceback):
     """Base cache error ({})."""
 
 
-class Cache:
-    """
-    Generic API for cache objects.
-    """
-
-    def __init__(self, config=None):
-
-        if not isinstance(config, (dict, type(None))):
-            raise TypeError("Invalid type for 'config'.")
-
-        self._config = config
-
-        if config:
-            self.init_cache(config=config)
-
-    def init_cache(self, config={}):
-
-        config.setdefault('CACHE_TYPE', 'null')
-        config.setdefault('CACHE_KWARGS', {})
-
-        self._set_cache(config)
-
-    def _set_cache(self, config):
-
-        cache_map = {
-            'null': NullCache,
-            'redis': RedisCache,
-            'fs': FileSystemCache,
-        }
-
-        cache_obj = cache_map[config['CACHE_TYPE']]
-        self._cache = cache_obj(**config['CACHE_KWARGS'])
-
-    def get(self, *args, **kwargs):
-        return self._cache.get(*args, **kwargs)
-
-    def set(self, *args, **kwargs):
-        return self._cache.set(*args, **kwargs)
-
-    def delete(self, *args, **kwargs):
-        return self._cache.delete(*args, **kwargs)
-
-    def __contains__(self, *args, **kwargs):
-        return self._cache.__contains__(*args, **kwargs)
-
-
 # -----------------------------------------------------------------------------
 class CachingBackend:
     """
@@ -375,3 +329,48 @@ class FileSystemCache(CachingBackend):
         """
 
         return gzip.decompress(value)
+
+
+# -----------------------------------------------------------------------------
+class Cache:
+    """
+    Generic API for cache objects.
+    """
+    CACHE_MAP = {
+        'null': NullCache,
+        'redis': RedisCache,
+        'fs': FileSystemCache,
+    }
+
+    def __init__(self, config=None):
+
+        if not isinstance(config, (dict, type(None))):
+            raise TypeError("Invalid type for 'config'.")
+
+        self._config = config
+
+        if config:
+            self.init_cache(config=config)
+
+    def init_cache(self, config={}):
+
+        config.setdefault('CACHE_TYPE', 'null')
+        config.setdefault('CACHE_KWARGS', {})
+
+        self._set_cache(config)
+
+    def _set_cache(self, config):
+        cache_obj = self.CACHE_MAP[config['CACHE_TYPE']]
+        self._cache = cache_obj(**config['CACHE_KWARGS'])
+
+    def get(self, *args, **kwargs):
+        return self._cache.get(*args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        return self._cache.set(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self._cache.delete(*args, **kwargs)
+
+    def __contains__(self, *args, **kwargs):
+        return self._cache.__contains__(*args, **kwargs)

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -222,7 +222,7 @@ class FileSystemCache(CachingBackend):
         """
         Return a list of (fully qualified) cache filenames.
         """
-        mgmt_files = [self._get_filename(name).split('/')[-1]
+        mgmt_files = [self._get_filename(name).split(os.sep)[-1]
                       for name in (self._fs_count_file,)]
         return [os.path.join(self._path, fn) for fn in os.listdir(self._path)
                 if not fn.endswith(self._fs_transaction_suffix) and

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -176,7 +176,6 @@ class RedisCache(CachingBackend):
 
         timeout = self._normalize_timeout(timeout)
 
-        print(value)
         if timeout == 0:
             return self.redis.set(name=key, value=value)
         else:

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Caching facilities
 

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -44,6 +44,11 @@ class CachingBackend:
         """
         self._default_timeout = default_timeout
 
+    def _normalize_timeout(self, timeout):
+        if timeout is None:
+            return self._default_timeout
+        return timeout
+
     def get(self, key):
         """
         Look up ``key`` in the cache and return the value for it.
@@ -118,11 +123,6 @@ class RedisCache(CachingBackend):
         if isinstance(self.key_prefix, str):
             return self.key_prefix
         return self.key_prefix()
-
-    def _normalize_timeout(self, timeout):
-        if timeout is None:
-            return self._default_timeout
-        return timeout
 
     def get(self, key):
         return self._deserialize(
@@ -211,8 +211,7 @@ class FileSystemCache(CachingBackend):
         self.set(self._fs_count_file, str(new_count), mgmt_element=True)
 
     def _normalize_timeout(self, timeout):
-        if timeout is None:
-            timeout = self._default_timeout
+        timeout = super()._normalize_timeout(timeout)
 
         if timeout != 0:
             timeout = time() + timeout

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -7,6 +7,7 @@ The module provides a similar functionality as implemented by `pallets/cachelib
 <https://github.com/sh4nks/flask-caching>`_.
 """
 
+import gzip
 import redis
 import string
 
@@ -186,7 +187,15 @@ class RedisCache(CachingBackend):
         return self.redis.exists(self._create_key_prefix() + key)
 
     def _serialize(self, value):
-        return value
+        return gzip.compress(value.encode('utf-8'))
 
     def _deserialize(self, value):
-        return value
+        """
+        The complementary method of :py:meth:`_serialize`. Can be called with
+        ``None``.
+        """
+
+        if value is None:
+            return None
+
+        return gzip.decompress(value)

--- a/eidangservices/federator/server/cache.py
+++ b/eidangservices/federator/server/cache.py
@@ -1,0 +1,192 @@
+"""
+Caching facilities
+
+The module provides a similar functionality as implemented by `pallets/cachelib
+<https://github.com/pallets/cachelib>`_ and `sh4nks/flask-caching
+<https://github.com/sh4nks/flask-caching>`_.
+"""
+
+import redis
+import string
+
+from eidangservices.utils.error import ErrorWithTraceback
+
+
+# Used to remove control characters and whitespace from cache keys.
+valid_chars = set(string.ascii_letters + string.digits + "_.")
+delchars = "".join(c for c in map(chr, range(256)) if c not in valid_chars)
+null_control = (dict((k, None) for k in delchars),)
+
+
+# -----------------------------------------------------------------------------
+class CacheError(ErrorWithTraceback):
+    """Base cache error ({})."""
+
+
+class Cache:
+    """
+    Generic API for cache objects.
+    """
+
+    def __init__(self, config=None):
+
+        if not isinstance(config, (dict, type(None))):
+            raise TypeError("Invalid type for 'config'.")
+
+        self._config = config
+
+        if config:
+            self.init_cache(config=config)
+
+    def init_cache(self, config={}):
+
+        config.setdefault('CACHE_TYPE', 'null')
+        config.setdefault('CACHE_KWARGS', {})
+
+        self._set_cache(config)
+
+    def _set_cache(self, config):
+
+        cache_map = {
+            'null': NullCache,
+            'redis': RedisCache,
+        }
+
+        cache_obj = cache_map[config['CACHE_TYPE']]
+        self._cache = cache_obj(**config['CACHE_KWARGS'])
+
+    def get(self, *args, **kwargs):
+        return self._cache.get(*args, **kwargs)
+
+    def set(self, *args, **kwargs):
+        return self._cache.set(*args, **kwargs)
+
+    def delete(self, *args, **kwargs):
+        return self._cache.delete(*args, **kwargs)
+
+    def __contains__(self, *args, **kwargs):
+        return self._cache.__contains__(*args, **kwargs)
+
+
+# -----------------------------------------------------------------------------
+class CachingBackend:
+    """
+    Base class for cache backend implementations.
+    """
+
+    def __init__(self, default_timeout=300, **kwargs):
+        """
+        :param default_timeout: The default timeout (in seconds) that is used
+        if no timeout is specified in :py:meth:`set`. A timeout of 0 indicates
+        that the cache never expires.
+        """
+        self._default_timeout = default_timeout
+
+    def get(self, key):
+        """
+        Look up ``key`` in the cache and return the value for it.
+
+        :param key: The key to be looked up
+        :returns: The value if it exists and is readable, else ``None``.
+        """
+
+        return None
+
+    def delete(self, key):
+        """
+        Delete ``key`` from the cache.
+
+        :param key: The key to delete
+        :returns: Whether the key existed and has been deleted.
+        :rtype: boolean
+        """
+
+        return True
+
+    def set(self, key, value, timeout=None):
+        """
+        Add a new ``key: value`` to the cache. The value is overwritten in case
+        the ``key`` is already cached.
+
+        :param key: The key to be set
+        :param value: The value to be cached
+        :param timeout: The cache timeout for the key in seconds. If not
+            specified the default timeout is used. A timeout of 0 indicates
+            that the cache never expires.
+
+        :returns: ``True`` if the key has been updated and ``False`` for
+            backend errors.
+        rtype: boolean
+        """
+
+        return True
+
+    def __contains__(self, key):
+        """
+        Validate if a key exists in the cache without returning it. The data is
+        neither loaded nor deserialized.
+
+        :param key: Key to validate
+        """
+
+        raise NotImplementedError
+
+
+class NullCache(CachingBackend):
+    """
+    A cache that doesn't cache.
+    """
+
+    def __contains__(self, key):
+        return False
+
+
+class RedisCache(CachingBackend):
+    """
+    Implementation of a `Redis <https://redis.io/>`_ caching backend.
+    """
+
+    def __init__(self, url, default_timeout=300, key_prefix=None, **kwargs):
+        super().__init__(default_timeout)
+
+        self.redis = redis.Redis.from_url(url)
+        self.key_prefix = key_prefix or ""
+
+    def _create_key_prefix(self):
+        if isinstance(self.key_prefix, str):
+            return self.key_prefix
+        return self.key_prefix()
+
+    def _normalize_timeout(self, timeout):
+        if timeout is None:
+            return self._default_timeout
+        return timeout
+
+    def get(self, key):
+        return self._deserialize(
+            self.redis.get(self._create_key_prefix() + key))
+
+    def delete(self, key):
+        return self.redis.delete(self._create_key_prefix() + key)
+
+    def set(self, key, value, timeout=None):
+        key = self._create_key_prefix() + key
+        value = self._serialize(value)
+
+        timeout = self._normalize_timeout(timeout)
+
+        print(value)
+        if timeout == 0:
+            return self.redis.set(name=key, value=value)
+        else:
+            return self.redis.setex(
+                name=key, value=value, time=timeout)
+
+    def __contains__(self, key):
+        return self.redis.exists(self._create_key_prefix() + key)
+
+    def _serialize(self, value):
+        return value
+
+    def _deserialize(self, value):
+        return value

--- a/eidangservices/federator/server/mixin.py
+++ b/eidangservices/federator/server/mixin.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 
-from eidangservices.federator.server import response_code_stats
+import base64
+import hashlib
+
+from eidangservices.federator.server import cache, response_code_stats
+from eidangservices.federator.server.cache import null_control
 
 
 class ClientRetryBudgetMixin:
@@ -44,3 +48,82 @@ class ClientRetryBudgetMixin:
             garbage collected
         """
         self.stats_retry_budget_client.gc(url)
+
+
+class CachingMixin:
+    """
+    Adds caching facilities to a
+    :py:class:`~eidangservices.federator.server.process.RequestProcessor`.
+    """
+
+    def make_cache_key(self, query_params, stream_epochs, key_prefix=None,
+                       sort_args=True, hash_method=hashlib.md5):
+        """
+        Create a cache key from ``query_params`` and ``stream_epochs``.
+
+        :param query_params: Mapping with requested query parameters
+        :param stream_epochs: List of
+            :py:class:`~eidangservices.utils.sncl.StreamEpoch` objects.
+        :param key_prefix: Caching key prefix
+        :param bool sort_args: Sort caching key components before creating the
+            key.
+        :param hash_method: Hash method used for key generation. Default is
+            ``hashlib.md5``.
+        """
+        if sort_args:
+            query_params = sorted(query_params)
+            stream_epochs = sorted(stream_epochs)
+
+        updated = "{0}{1}{2}".format(
+            key_prefix or '', query_params, stream_epochs)
+        updated.translate(*null_control)
+
+        cache_key = hash_method()
+        cache_key.update(updated.encode("utf-8"))
+        cache_key = base64.b64encode(cache_key.digest())[:16]
+        cache_key = cache_key.decode("utf-8")
+
+        return cache_key
+
+    def cache_stream(self, generator, cache_key, timeout=None):
+        """
+        Caching generator wrapper for ``generator``.
+        """
+
+        stream_buffer = []
+        try:
+            for chunk in generator:
+                stream_buffer.append(chunk)
+                yield chunk
+        except GeneratorExit:
+            pass
+        else:
+            # cache streamed response
+            try:
+                cache.set(
+                    cache_key, "".join(stream_buffer), timeout=timeout)
+            except Exception as err:
+                raise err
+                # TODO TODO TODO
+                # Report warning
+                pass
+
+    def get_cache(self, cache_key):
+        """
+        Lookup ``cache_key`` from the cache.
+        """
+
+        try:
+            retval = cache.get(cache_key)
+            found = True
+
+            # If the value returned by cache.get() is None, it might be
+            # because the key is not found in the cache or because the
+            # cached value is actually None
+            if retval is None:
+                found = cache_key in cache
+        except Exception:
+            found = False
+            return None, found
+        else:
+            return retval, found

--- a/eidangservices/federator/server/mixin.py
+++ b/eidangservices/federator/server/mixin.py
@@ -56,6 +56,10 @@ class CachingMixin:
     :py:class:`~eidangservices.federator.server.process.RequestProcessor`.
     """
 
+    @property
+    def cache(self):
+        return cache
+
     def make_cache_key(self, query_params, stream_epochs, key_prefix=None,
                        sort_args=True, hash_method=hashlib.md5):
         """

--- a/eidangservices/federator/server/mixin.py
+++ b/eidangservices/federator/server/mixin.py
@@ -61,7 +61,8 @@ class CachingMixin:
         return cache
 
     def make_cache_key(self, query_params, stream_epochs, key_prefix=None,
-                       sort_args=True, hash_method=hashlib.md5):
+                       sort_args=True, hash_method=hashlib.md5,
+                       exclude_params=('nodata', 'service',)):
         """
         Create a cache key from ``query_params`` and ``stream_epochs``.
 
@@ -73,8 +74,13 @@ class CachingMixin:
             key.
         :param hash_method: Hash method used for key generation. Default is
             ``hashlib.md5``.
+        :param exclude_params: Keys to be excluded from the ``query_params``
+            mapping while generating the key.
+        :type exclude_params: tuple of str
         """
         if sort_args:
+            query_params = [(k, v) for k, v in query_params.items()
+                            if k not in exclude_params]
             query_params = sorted(query_params)
             stream_epochs = sorted(stream_epochs)
 

--- a/eidangservices/federator/tests/cache.py
+++ b/eidangservices/federator/tests/cache.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Cache related test facilities.
+"""
+
+import os
+import shutil
+import tempfile
+import time
+import unittest
+
+from eidangservices.federator.server.cache import FileSystemCache
+
+
+class FileSystemCacheTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.cache_dir = os.path.join(tempfile.gettempdir(), '__fed_fs_cache')
+
+    def tearDown(self):
+        try:
+            shutil.rmtree(self.cache_dir)
+        except OSError:
+            pass
+
+    def test_init(self):
+        fs_cache = FileSystemCache(cache_dir=self.cache_dir)
+
+        self.assertEqual(fs_cache._file_count, 0)
+
+    def test_set_get_delete(self):
+        fs_cache = FileSystemCache(cache_dir=self.cache_dir)
+        fs_cache.set('key0', 'bar')
+        fs_cache.set('key1', 'hello world')
+
+        self.assertEqual(fs_cache._file_count, 2)
+
+        self.assertEqual(fs_cache.get('key0'), b'bar')
+        self.assertEqual(fs_cache.get('key1'), b'hello world')
+
+        fs_cache.delete('key1')
+
+        self.assertEqual(fs_cache._file_count, 1)
+        self.assertEqual(fs_cache.get('key0'), b'bar')
+
+    def test_threshold(self):
+        fs_cache = FileSystemCache(cache_dir=self.cache_dir, threshold=4)
+
+        # XXX(damb): Removal is firstly initiated if the cache contains
+        # (threshold + 2) files.
+        fs_cache.set('key0', 'baz')
+        fs_cache.set('key1', 'bar')
+        fs_cache.set('key2', 'hello')
+        fs_cache.set('key3', 'world')
+        fs_cache.set('key4', 'foo')
+        fs_cache.set('key5', 'foobar')
+
+        self.assertEqual(fs_cache._file_count, 4)
+
+    def test_timeout(self):
+        fs_cache = FileSystemCache(cache_dir=self.cache_dir, default_timeout=1)
+        fs_cache.set('key0', 'foo')
+
+        time.sleep(1)
+
+        self.assertEqual(fs_cache.get('key0'), None)
+        self.assertEqual(fs_cache._file_count, 1)

--- a/eidangservices/settings.py
+++ b/eidangservices/settings.py
@@ -595,6 +595,11 @@ EIDA_FEDERATOR_RESOURCE_CONFIG = {
     }
 }
 
+EIDA_FEDERATOR_CACHE_CONFIG = {
+    'CACHE_TYPE': 'null',
+    'CACHE_KWARGS': {},
+}
+
 EIDA_FEDERATOR_REQUEST_STRATEGIES = (
     'granular',
     'bulk',


### PR DESCRIPTION
**Features and Changes**:
- `eida-federator` implements a frontend-cache for requests of type `fdsnws-station` (`format=text|xml`)
- Two different flavors of Caching-Backends are provided:
  + *File system* backend (`"CACHE_TYPE": "fs"`) ( i.e. cache data is stored within a directory on the file system)
  + *Redis* backend (`"CACHE_TYPE": "redis"`) which may be used if a distributed cache is required
- Both backends allow a configurable TTL for cached data.
- Cached data is stored [gzip](https://en.wikipedia.org/wiki/Gzip) encoded
- Data is cached only if the response was returned successfully and completely
- The `docker/prod` setup currently comes along with a configured file system caching backend (TTL = 12 hours)
- The implementation solves most of the disadvantages mentioned in PR #92 (e.g. works both for HTTP GET and POST requests)

Note, that caching streamed data requires temporarily buffering responses in memory.

---
**Examples:**

Issue a first request for `network=CH,AW,BW,GR`:
```
$ $ time curl -v -o /dev/null "http://mediator-devel.ethz.ch/fdsnws/station/1/query?network=CH,AW,BW,GR&format=text"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 129.132.144.211...
* TCP_NODELAY set
* Connected to mediator-devel.ethz.ch (129.132.144.211) port 80 (#0)
> GET /fdsnws/station/1/query?network=CH,AW,BW,GR&format=text HTTP/1.1
> Host: mediator-devel.ethz.ch
> User-Agent: curl/7.58.0
> Accept: */*
> 
  0     0    0     0    0     0      0      0 --:--:--  0:00:02 --:--:--     0< HTTP/1.1 200 OK
< Date: Mon, 23 Dec 2019 20:10:30 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Access-Control-Allow-Origin: *
< Vary: Accept-Encoding
< Transfer-Encoding: chunked
< Content-Type: text/plain; charset=utf-8
< 
{ [79 bytes data]
100 49545    0 49545    0     0   1964      0 --:--:--  0:00:25 --:--:--   799
* Connection #0 to host mediator-devel.ethz.ch left intact

real	0m25.241s
user	0m0.012s
sys	0m0.036s
```

Issue the same request, again:
```
$ time curl -v -o /dev/null "http://mediator-devel.ethz.ch/fdsnws/station/1/query?network=CH,AW,BW,GR&format=text"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 129.132.144.211...
* TCP_NODELAY set
* Connected to mediator-devel.ethz.ch (129.132.144.211) port 80 (#0)
> GET /fdsnws/station/1/query?network=CH,AW,BW,GR&format=text HTTP/1.1
> Host: mediator-devel.ethz.ch
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 23 Dec 2019 20:12:37 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Access-Control-Allow-Origin: *
< Content-Length: 49545
< Vary: Accept-Encoding
< Content-Type: text/plain; charset=utf-8
< 
{ [14273 bytes data]
100 49545  100 49545    0     0  2546k      0 --:--:-- --:--:-- --:--:-- 2546k
* Connection #0 to host mediator-devel.ethz.ch left intact

real	0m0.032s
user	0m0.009s
sys	0m0.004s
```

Same but now with alias `net`:

```
$ time curl -v -o /dev/null "http://mediator-devel.ethz.ch/fdsnws/station/1/query?net=CH,AW,BW,GR&format=text"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 129.132.144.211...
* TCP_NODELAY set
* Connected to mediator-devel.ethz.ch (129.132.144.211) port 80 (#0)
> GET /fdsnws/station/1/query?net=CH,AW,BW,GR&format=text HTTP/1.1
> Host: mediator-devel.ethz.ch
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 23 Dec 2019 20:13:52 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Access-Control-Allow-Origin: *
< Content-Length: 49545
< Vary: Accept-Encoding
< Content-Type: text/plain; charset=utf-8
< 
{ [14273 bytes data]
100 49545  100 49545    0     0  2303k      0 --:--:-- --:--:-- --:--:-- 2419k
* Connection #0 to host mediator-devel.ethz.ch left intact

real	0m0.036s
user	0m0.013s
sys	0m0.004s
```

Same but now with differently ordered network-codes i.e.: `network=GR,AW,CH,BW`
```
$ time curl -v -o /dev/null "http://mediator-devel.ethz.ch/fdsnws/station/1/query?network=GR,AW,CH,BW&format=text"
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 129.132.144.211...
* TCP_NODELAY set
* Connected to mediator-devel.ethz.ch (129.132.144.211) port 80 (#0)
> GET /fdsnws/station/1/query?network=GR,AW,CH,BW&format=text HTTP/1.1
> Host: mediator-devel.ethz.ch
> User-Agent: curl/7.58.0
> Accept: */*
> 
< HTTP/1.1 200 OK
< Date: Mon, 23 Dec 2019 20:15:07 GMT
< Server: Apache/2.4.18 (Ubuntu)
< Access-Control-Allow-Origin: *
< Content-Length: 49545
< Vary: Accept-Encoding
< Content-Type: text/plain; charset=utf-8
< 
{ [14273 bytes data]
100 49545  100 49545    0     0  2303k      0 --:--:-- --:--:-- --:--:-- 2303k
* Connection #0 to host mediator-devel.ethz.ch left intact

real	0m0.037s
user	0m0.006s
sys	0m0.009s
```