### PR TITLE
Upgrade to phusion/baseimage:0.11

### DIFF
--- a/docker/prod/federator/Dockerfile
+++ b/docker/prod/federator/Dockerfile
@@ -13,7 +13,7 @@
 # docker exec -it eida-federator /bin/bash
 
 # Base image
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 # Add label metadata
 LABEL maintainer="Mathijs Koymans"

--- a/docker/prod/federator/Dockerfile
+++ b/docker/prod/federator/Dockerfile
@@ -53,12 +53,12 @@ WORKDIR /var/www/mediatorws
 
 # Create the virtual environments
 RUN mkdir /var/www/federator && cd /var/www/federator && \
-    virtualenv -p $(which python3.5) venv3 && \
+    virtualenv -p $(which python3.6) venv3 && \
     /bin/bash -c "source /var/www/federator/venv3/bin/activate && \
     make -C /var/www/mediatorws install SERVICES=federator && deactivate"
 
 RUN mkdir /var/www/stationlite && cd /var/www/stationlite && \
-    virtualenv -p $(which python3.5) venv3 && \
+    virtualenv -p $(which python3.6) venv3 && \
     /bin/bash -c "source /var/www/stationlite/venv3/bin/activate && \
     pip install numpy psycopg2 && \
     make -C /var/www/mediatorws install SERVICES=stationlite && deactivate"

--- a/docker/prod/proxy/Dockerfile
+++ b/docker/prod/proxy/Dockerfile
@@ -11,7 +11,7 @@
 # docker exec -it eida-federator-proxy /bin/bash
 
 # Base image
-FROM phusion/baseimage:latest
+FROM phusion/baseimage:0.11
 
 # Add label metadata
 LABEL maintainer="Daniel Armbruster"


### PR DESCRIPTION
**Features and Changes**:

- Since using the `latest` tag for `phusion/baseimage` is not recommended (see: https://github.com/phusion/baseimage-docker/issues/467) tag **0.11** is set explicitly. As a consequence, the image is now based on Ubuntu 18.04 LTS which comes along with Python 3.6 as default.