### PR TITLE
Reconfigure timeouts

### DIFF
--- a/docker/prod/federator/federator.conf
+++ b/docker/prod/federator/federator.conf
@@ -13,11 +13,7 @@
 
         # EIDA StationLite Webservice
         WSGIDaemonProcess stationlite user=www-data group=www-data  processes=5 threads=5 python-home=/var/www/stationlite/venv3 display-name=%{GROUP}
-        WSGIScriptAlias /eidaws/routing /var/www/mediatorws/apache2/stationlite.wsgi/eidaws/routing
-
-        <Location "/eidaws/routing">
-            WSGIProcessGroup stationlite
-        </Location>
+        WSGIScriptAlias /eidaws/routing /var/www/mediatorws/apache2/stationlite.wsgi/eidaws/routing process-group=stationlite
 
         <Directory "/var/www/mediatorws/eidangservices/stationlite">
             WSGIScriptReloading On
@@ -32,12 +28,8 @@
 
         # EIDA Federator Webservice
         WSGIDaemonProcess federator user=www-data group=www-data processes=10 threads=3 python-home=/var/www/federator/venv3 display-name=%{GROUP}
-        WSGIScriptAlias /fdsnws /var/www/mediatorws/apache2/federator.wsgi/fdsnws
-        WSGIScriptAlias /eidaws/wfcatalog /var/www/mediatorws/apache2/federator.wsgi/eidaws/wfcatalog
-
-        <Location ~ "/(fdsnws|eidaws/wfcatalog)">
-            WSGIProcessGroup federator
-        </Location>
+        WSGIScriptAlias /fdsnws /var/www/mediatorws/apache2/federator.wsgi/fdsnws process-group=federator
+        WSGIScriptAlias /eidaws/wfcatalog /var/www/mediatorws/apache2/federator.wsgi/eidaws/wfcatalog process-group=federator
 
         <Directory "/var/www/mediatorws/eidangservices/federator">
             WSGIScriptReloading On

--- a/docker/prod/federator/federator.conf
+++ b/docker/prod/federator/federator.conf
@@ -27,7 +27,7 @@
         </Directory>
 
         # EIDA Federator Webservice
-        WSGIDaemonProcess federator user=www-data group=www-data processes=10 threads=3 python-home=/var/www/federator/venv3 display-name=%{GROUP}
+        WSGIDaemonProcess federator user=www-data group=www-data processes=10 threads=3 python-home=/var/www/federator/venv3 display-name=%{GROUP} socket-timeout=900
         WSGIScriptAlias /fdsnws /var/www/mediatorws/apache2/federator.wsgi/fdsnws process-group=federator
         WSGIScriptAlias /eidaws/wfcatalog /var/www/mediatorws/apache2/federator.wsgi/eidaws/wfcatalog process-group=federator
 

--- a/eidangservices/settings.py
+++ b/eidangservices/settings.py
@@ -560,8 +560,10 @@ EIDA_FEDERATOR_DEFAULT_STORAGE_URL = \
 EIDA_FEDERATOR_DEFAULT_RESOURCES = (
     'fdsnws-dataselect', 'fdsnws-station', 'eidaws-wfcatalog')
 # timeout the federator is waiting before the first endpoint request must be
-# answered.
-EIDA_FEDERATOR_STREAMING_TIMEOUT = 600
+# answered. Note, when deploying with Apache2 and mod_wsgi: The timeout should
+# be less than the socket-timeout configured of the mod_wsgi WSGIDeamonProcess
+# in order to avoid Gateway errors.
+EIDA_FEDERATOR_STREAMING_TIMEOUT = 895
 # timeout (federator) for endpoint requests. Should be <
 # EIDA_FEDERATOR_STREAMING_TIMEOUT
 EIDA_FEDERATOR_ENDPOINT_TIMEOUT = 540


### PR DESCRIPTION
**Features and Changes**:
- Reconfigure timeouts (both webserver and WSGI application); Instead of a HTTP status code 504 (Gateway timeout) now HTTP status code 204 is returned.
- Timeouts were configured based on the response time of the request `/fdsnws/station/1/query?net=Z3&level=response` (neither frontend-caching nor backend-caching involved).

Closes #104.