### PR TITLE
Fix query stream epoch with time constraints

### DIFF
--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -179,19 +179,19 @@ def find_streamepochs_and_routes(session, stream_epoch, service,
             # epoch is not routed
             continue
 
+        sta = row[5]
+        loc = row[1]
+        cha = row[0]
+
+        # NOTE(damb): level reduction
+        if level == 'network':
+            sta = loc = cha = '*'
+        elif level == 'station':
+            loc = cha = '*'
+
         # NOTE(damb): Set endtime to 'max' if undefined (i.e. device currently
         # acquiring data).
         with none_as_max(endtime) as end:
-            sta = row[5]
-            loc = row[1]
-            cha = row[0]
-
-            # NOTE(damb): level reduction
-            if level == 'network':
-                sta = loc = cha = '*'
-            elif level == 'station':
-                loc = cha = '*'
-
             stream_epochs = StreamEpochs(
                 network=row[4],
                 station=sta,

--- a/eidangservices/stationlite/server/routes/stationlite.py
+++ b/eidangservices/stationlite/server/routes/stationlite.py
@@ -123,11 +123,6 @@ class StationLiteResource(Resource):
                 minlon=args['minlongitude'],
                 maxlon=args['maxlongitude'])
 
-            # adjust stream_epoch regarding time_constraints
-            for url, streams in _routes:
-                streams.modify_with_temporal_constraints(
-                    start=stream_epoch.starttime,
-                    end=stream_epoch.endtime)
             routes.extend(_routes)
 
         # flatten response list

--- a/pm/EIDA-stationlite.postman_collection.json
+++ b/pm/EIDA-stationlite.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "0aed3b57-6af4-4722-9a4a-fd8fd69d595b",
+		"_postman_id": "04aa0f39-1291-43e0-82c0-8a9ec6e30f74",
 		"name": "EIDA/stationlite",
 		"description": "API and integration tests for the EIDA stationlite webservice.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -24,7 +24,7 @@
 							"});",
 							"",
 							"pm.test(\"Body is correct\", function () {",
-							"    pm.response.to.have.body(\"0.9.5rc2\");",
+							"    pm.response.to.have.body(\"0.9.7\");",
 							"});"
 						],
 						"type": "text/javascript"
@@ -1335,6 +1335,832 @@
 					]
 				},
 				"description": "Multi route; two nets; two stas:\n\nlevel=channel\nnet=CH,GR\nsta=HASLI,BFO\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query",
+							"6G ATIM * * 2013-01-01T00:00:00 2016-12-31T23:59:59",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&format=post&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "format",
+							"value": "post"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch)\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=get&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query?network=6G&station=ATIM&location=*&channel=*&starttime=2013-01-01T00:00:00&endtime=2016-12-31T23:59:59",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&format=get&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "format",
+							"value": "get"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch)\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=get"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query",
+							"6G ATIM * * 2013-01-01T00:00:00 2016-12-31T23:59:59",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&format=post&level=station&start=2012-01-01",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "format",
+							"value": "post"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						},
+						{
+							"key": "start",
+							"value": "2012-01-01"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime before route epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=get&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query?network=6G&station=ATIM&location=*&channel=*&starttime=2013-01-01T00:00:00&endtime=2016-12-31T23:59:59",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&format=get&level=station&start=2012-01-01",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "format",
+							"value": "get"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						},
+						{
+							"key": "start",
+							"value": "2012-01-01"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime before route epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=get"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 204\", function () {",
+							"    pm.response.to.have.status(204);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&start=2019-01-01&format=post&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "start",
+							"value": "2019-01-01"
+						},
+						{
+							"key": "format",
+							"value": "post"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime after epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=get&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 204\", function () {",
+							"    pm.response.to.have.status(204);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&start=2019-01-01&format=get&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "start",
+							"value": "2019-01-01"
+						},
+						{
+							"key": "format",
+							"value": "get"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime after epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query",
+							"6G ATIM * * 2015-01-01T00:00:00 2016-12-31T23:59:59",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&start=2015-01-01&format=post&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "start",
+							"value": "2015-01-01"
+						},
+						{
+							"key": "format",
+							"value": "post"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime after epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=get&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query?network=6G&station=ATIM&location=*&channel=*&starttime=2015-01-01T00:00:00&endtime=2016-12-31T23:59:59",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&start=2015-01-01&format=get&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "start",
+							"value": "2015-01-01"
+						},
+						{
+							"key": "format",
+							"value": "get"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime after epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=get"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query",
+							"6G ATIM * * 2015-01-01T00:00:00 2016-01-01T00:00:00",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&start=2015-01-01&end=2016-01-01&format=post&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "start",
+							"value": "2015-01-01"
+						},
+						{
+							"key": "end",
+							"value": "2016-01-01"
+						},
+						{
+							"key": "format",
+							"value": "post"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime and endtime during epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=get&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query?network=6G&station=ATIM&location=*&channel=*&starttime=2015-01-01T00:00:00&endtime=2016-01-01T00:00:00",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query?service=station&net=6G&sta=ATIM&start=2015-01-01&end=2016-01-01&format=get&level=station",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					],
+					"query": [
+						{
+							"key": "service",
+							"value": "station"
+						},
+						{
+							"key": "net",
+							"value": "6G"
+						},
+						{
+							"key": "sta",
+							"value": "ATIM"
+						},
+						{
+							"key": "start",
+							"value": "2015-01-01"
+						},
+						{
+							"key": "end",
+							"value": "2016-01-01"
+						},
+						{
+							"key": "format",
+							"value": "get"
+						},
+						{
+							"key": "level",
+							"value": "station"
+						}
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime and endtime during epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=get"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query",
+							"6G ATIM * * 2015-01-01T00:00:00 2016-01-01T00:00:00",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "format=post\nservice=station\nlevel=station\n\n6G ATIM * * 2015-01-01 2016-01-01"
+				},
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) with starttime and endtime during epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
+			},
+			"response": []
+		},
+		{
+			"name": "query?service=station&net=6G&sta=ATIM&format=post&level=station",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d706bfed-c976-470a-a5d4-3fec365bd5cd",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Header is valid\", function () {",
+							"    pm.response.to.have.header(\"Content-Type\");",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/plain\");",
+							"});",
+							"",
+							"pm.test(\"Body is correct\", function () {",
+							"    var reference_result =",
+							"`http://${pm.environment.get('fed_proxy')}eida-service.koeri.boun.edu.tr/fdsnws/station/1/query",
+							"6G ATIM * * 2014-01-01T00:00:00 2016-01-01T00:00:00",
+							"`;",
+							"    pm.response.to.have.body(reference_result);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "format=post\nservice=station\nlevel=station\n\n6G ATIM * * 2014-01-01 2015-01-01\n6G ATIM * * 2015-02-01 2016-01-01"
+				},
+				"url": {
+					"raw": "{{url_base}}:{{port_stl}}/eidaws/routing/1/query",
+					"host": [
+						"{{url_base}}"
+					],
+					"port": "{{port_stl}}",
+					"path": [
+						"eidaws",
+						"routing",
+						"1",
+						"query"
+					]
+				},
+				"description": "Single route; len(channel epoch) > len(route epoch) two epochs requested each with a starttime and endtime during routed epoch\n\nlevel=station\nnet=6G\nsta=ATIM\nformat=post"
 			},
 			"response": []
 		},


### PR DESCRIPTION
**Bugfix**:
- Correctly handle cases where the routed epoch is a subset of the channel epoch.