### PR TITLE
Allow configuration of limits for RequestTooLarge response

### DIFF
--- a/config/eidangws_config
+++ b/config/eidangws_config
@@ -44,28 +44,41 @@
 #   {"num_threads": 10,
 #    "request_strategy": "granular",
 #    "request_method": "POST",
-#    "proxy_netloc": null},
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null},
 #  "fdsnws-station-xml":
 #   {"num_threads": 5,
 #    "request_strategy": "adaptive-bulk",
 #    "request_method": "POST",
-#    "proxy_netloc": null},
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null},
 #  "fdsnws-station-text": 
 #   {"num_threads": 10,
 #    "request_strategy": "bulk",
 #    "request_method": "POST",
-#    "proxy_netloc": null},
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null},
 #  "eidaws-wfcatalog":
 #   {"num_threads": 10,
 #    "request_strategy": "granular",
 #    "request_method": "POST",
-#    "proxy_netloc": null}}'
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null}}'
 # 
 # When configuring "proxy_netloc", then the routing service is forced to
 # prepend a constant network location to routed URLs.  This option may be used
 # if requests are redirected e.g. when using a proxy. Set to *null* if
 # redirecting should be disabled.
 # See also: https://tools.ietf.org/html/rfc1738#section-3.1
+#
+# "max_stream_epoch_duration" refers to the maximum allowed routed stream epoch
+# duration in days before HTTP status code 413 is raised.
+# "max_total_stream_epoch_duration" refers to the maxium allowed total routed
+# stream epoch duration before HTTP status code 413 is raised.
 #
 # NOTE: For "fdsnws-station-xml" the number of download threads ("num_threads")
 # scales squared.

--- a/config/eidangws_config
+++ b/config/eidangws_config
@@ -75,6 +75,8 @@
 # redirecting should be disabled.
 # See also: https://tools.ietf.org/html/rfc1738#section-3.1
 #
+# Also, make sure that the proxy configured is reachable by eida-federator.
+#
 # "max_stream_epoch_duration" refers to the maximum allowed routed stream epoch
 # duration in days before HTTP status code 413 is raised.
 # "max_total_stream_epoch_duration" refers to the maxium allowed total routed

--- a/docker/prod/federator/eidangws_config
+++ b/docker/prod/federator/eidangws_config
@@ -44,24 +44,35 @@ storage=redis://federator-redis:6379/0
 #   {"num_threads": 10,
 #    "request_strategy": "granular",
 #    "request_method": "POST",
-#    "proxy_netloc": null},
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null},
 #  "fdsnws-station-xml":
 #   {"num_threads": 5,
 #    "request_strategy": "adaptive-bulk",
 #    "request_method": "POST",
-#    "proxy_netloc": null},
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null},
 #  "fdsnws-station-text": 
 #   {"num_threads": 10,
 #    "request_strategy": "bulk",
 #    "request_method": "POST",
-#    "proxy_netloc": null},
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null},
 #  "eidaws-wfcatalog":
 #   {"num_threads": 10,
 #    "request_strategy": "granular",
 #    "request_method": "POST",
-#    "proxy_netloc": null}}'
+#    "proxy_netloc": null,
+#    "max_stream_epoch_duration": null,
+#    "max_total_stream_epoch_duration": null}}'
 # 
 resource_config = {
+ "fdsnws-dataselect":
+  {"max_stream_epoch_duration": 35,
+   "max_total_stream_epoch_duration": 1000},
  "fdsnws-station-xml":
   {"request_strategy": "combining",
    "request_method": "GET",
@@ -78,6 +89,11 @@ resource_config = {
 # See also: https://tools.ietf.org/html/rfc1738#section-3.1
 #
 # Also, make sure that the proxy configured is reachable by eida-federator.
+#
+# "max_stream_epoch_duration" refers to the maximum allowed routed stream epoch
+# duration in days before HTTP status code 413 is raised.
+# "max_total_stream_epoch_duration" refers to the maxium allowed total routed
+# stream epoch duration before HTTP status code 413 is raised.
 #
 # NOTE: For "fdsnws-station-xml" the number of download threads ("num_threads")
 # scales squared.

--- a/eidangservices/federator/server/app.py
+++ b/eidangservices/federator/server/app.py
@@ -7,6 +7,7 @@ Launch EIDA NG Federator.
 import argparse
 import collections
 import copy
+import datetime
 import inspect
 import json
 import os
@@ -90,6 +91,21 @@ def resource_config(config_dict):
                     raise argparse.ArgumentTypeError(str(err))
                 else:
                     v = '//' + r.netloc
+
+            if (strict and k in ('max_stream_epoch_duration',
+                                 'max_total_stream_epoch_duration')):
+                if v is None:
+                    continue
+
+                try:
+                    delta = datetime.timedelta(days=v)
+
+                    if (delta <= datetime.timedelta()):
+                        raise ValueError(
+                            'Invalid max (total) stream epoch duration value: '
+                            '{}'.format(delta))
+                except Exception as err:
+                    raise argparse.ArgumentTypeError(str(err))
 
     try:
         config_dict = json.loads(config_dict)

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -217,9 +217,6 @@ class RequestProcessor(ClientRetryBudgetMixin):
     def _route(self):
         """
         Route a federating request.
-
-        :retval: Number of routes received
-        :rtype: int
         """
         # XXX(damb): Configure access=closed if routing restricted data is
         # required.

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -167,7 +167,7 @@ class RequestProcessor(ClientRetryBudgetMixin):
 
         if (None not in (self._max_total_stream_epoch_duration,
                          self._max_stream_epoch_duration) and
-            self._max_total_stream_epoch_duration <=
+            self._max_total_stream_epoch_duration <
                 self._max_stream_epoch_duration):
             self.logger.warning(
                 'Invalid max_(total)_stream_epoch_duration configuration. '

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -214,7 +214,7 @@ class RequestProcessor(ClientRetryBudgetMixin):
             raise FDSNHTTPError.create(self._nodata)
 
         if (self._max_total_stream_epoch_duration is not None and
-            self._strategy.total_stream_duration >=
+            self._strategy.total_stream_duration >
                 self._max_total_stream_epoch_duration):
             raise FDSNHTTPError.create(413, service_version=__version__)
 

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -165,6 +165,15 @@ class RequestProcessor(ClientRetryBudgetMixin):
         except TypeError:
             self._max_total_stream_epoch_duration = None
 
+        if (None not in (self._max_total_stream_epoch_duration,
+                         self._max_stream_epoch_duration) and
+            self._max_total_stream_epoch_duration <=
+                self._max_stream_epoch_duration):
+            self.logger.warning(
+                'Invalid max_(total)_stream_epoch_duration configuration. '
+                'Limits are defined by the "max_total_stream_epoch_duration" '
+                'parameter.')
+
         self._post = True
 
     @staticmethod

--- a/eidangservices/federator/server/process.py
+++ b/eidangservices/federator/server/process.py
@@ -296,7 +296,7 @@ class RequestProcessor(ClientRetryBudgetMixin):
                     'No valid results to be federated. ({})'.format(
                         ('No valid results.' if not self._results else
                          'Timeout ({}).'.format(timeout))))
-                raise FDSNHTTPError.create(self._nodata)
+                raise FDSNHTTPError.create(413, service_version=__version__)
 
     def _terminate(self):
         """

--- a/eidangservices/federator/server/strategy.py
+++ b/eidangservices/federator/server/strategy.py
@@ -190,7 +190,7 @@ class RequestStrategyBase(ClientRetryBudgetMixin):
 
                         duration = se.duration
                         if (max_stream_epoch_duration is not None and
-                                duration >= max_stream_epoch_duration):
+                                duration > max_stream_epoch_duration):
                             raise FDSNHTTPError.create(
                                 413, service_version=__version__)
 

--- a/eidangservices/federator/server/strategy.py
+++ b/eidangservices/federator/server/strategy.py
@@ -192,7 +192,7 @@ class RequestStrategyBase(ClientRetryBudgetMixin):
                         if (max_stream_epoch_duration is not None and
                                 duration >= max_stream_epoch_duration):
                             raise FDSNHTTPError.create(
-                                413, service=__version__)
+                                413, service_version=__version__)
 
                         try:
                             total_stream_duration += duration

--- a/eidangservices/federator/server/strategy.py
+++ b/eidangservices/federator/server/strategy.py
@@ -183,8 +183,11 @@ class RequestStrategyBase(ClientRetryBudgetMixin):
                         se = StreamEpoch.from_snclline(
                             line, default_endtime=(
                                 self._default_endtime if post else None))
+                        try:
+                            total_stream_duration += se.duration
+                        except OverflowError:
+                            total_stream_duration = datetime.timedelta.max
 
-                        total_stream_duration += se.duration
                         stream_epochs.append(se)
 
         except NoContent as err:
@@ -297,7 +300,9 @@ class GranularRequestStrategy(RequestStrategyBase):
         routing_table, total_stream_duration = super()._route(req, **kwargs)
         self._filter_by_client_retry_budget(
             routing_table, retry_budget_client,
-            total_stream_duration=total_stream_duration)
+            total_stream_duration=(total_stream_duration if
+                                   datetime.timedelta.max !=
+                                   total_stream_duration else None))
         self._routing_table_raw = routing_table
         self._total_stream_duration = total_stream_duration
 
@@ -350,7 +355,9 @@ class NetworkBulkRequestStrategy(RequestStrategyBase):
         routing_table, total_stream_duration = super()._route(req, **kwargs)
         self._filter_by_client_retry_budget(
             routing_table, retry_budget_client,
-            total_stream_duration=total_stream_duration)
+            total_stream_duration=(total_stream_duration if
+                                   datetime.timedelta.max !=
+                                   total_stream_duration else None))
         self._routing_table_raw = routing_table
         self._total_stream_duration = total_stream_duration
 
@@ -414,7 +421,9 @@ class AdaptiveNetworkBulkRequestStrategy(NetworkBulkRequestStrategy):
         routing_table, total_stream_duration = super()._route(req, **kwargs)
         self._filter_by_client_retry_budget(
             routing_table, retry_budget_client,
-            total_stream_duration=total_stream_duration)
+            total_stream_duration=(total_stream_duration if
+                                   datetime.timedelta.max !=
+                                   total_stream_duration else None))
         self._routing_table_raw = routing_table
         self._total_stream_duration = total_stream_duration
 
@@ -492,7 +501,9 @@ class NetworkCombiningRequestStrategy(RequestStrategyBase):
         routing_table, total_stream_duration = super()._route(req, **kwargs)
         self._filter_by_client_retry_budget(
             routing_table, retry_budget_client,
-            total_stream_duration=total_stream_duration)
+            total_stream_duration=(total_stream_duration if
+                                   datetime.timedelta.max !=
+                                   total_stream_duration else None))
         self._routing_table_raw = routing_table
         self._total_stream_duration = total_stream_duration
 

--- a/eidangservices/settings.py
+++ b/eidangservices/settings.py
@@ -583,6 +583,11 @@ EIDA_FEDERATOR_THREADS_WFCATALOG = 10
 EIDA_FEDERATOR_DEFAULT_HTTP_METHOD = 'POST'
 # default netloc prefixed to all URLs (used for routing service)
 EIDA_FEDERATOR_DEFAULT_NETLOC_PROXY = None
+# default maximum stream epoch days per single stream epoch before raising HTTP
+# code 413
+EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS = None
+# default maximum total stream epoch days before raising HTTP code 413
+EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS_TOTAL = None
 
 EIDA_FEDERATOR_RESOURCE_CONFIG = {
     "fdsnws-dataselect": {
@@ -590,24 +595,40 @@ EIDA_FEDERATOR_RESOURCE_CONFIG = {
         'request_strategy': 'granular',
         'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
         'proxy_netloc': EIDA_FEDERATOR_DEFAULT_NETLOC_PROXY,
+        'max_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS,
+        'max_total_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS_TOTAL,
     },
     "fdsnws-station-xml": {
         'num_threads': EIDA_FEDERATOR_THREADS_STATION_XML,
         'request_strategy': 'adaptive-bulk',
         'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
         'proxy_netloc': EIDA_FEDERATOR_DEFAULT_NETLOC_PROXY,
+        'max_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS,
+        'max_total_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS_TOTAL,
     },
     "fdsnws-station-text": {
         'num_threads': EIDA_FEDERATOR_THREADS_STATION_TEXT,
         'request_strategy': 'bulk',
         'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
         'proxy_netloc': EIDA_FEDERATOR_DEFAULT_NETLOC_PROXY,
+        'max_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS,
+        'max_total_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS_TOTAL,
     },
     "eidaws-wfcatalog": {
         'num_threads': EIDA_FEDERATOR_THREADS_WFCATALOG,
         'request_strategy': 'granular',
         'request_method': EIDA_FEDERATOR_DEFAULT_HTTP_METHOD,
         'proxy_netloc': EIDA_FEDERATOR_DEFAULT_NETLOC_PROXY,
+        'max_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS,
+        'max_total_stream_epoch_duration':
+        EIDA_FEDERATOR_DEFAULT_MAX_STREAM_EPOCH_DAYS_TOTAL,
     }
 }
 

--- a/eidangservices/utils/sncl.py
+++ b/eidangservices/utils/sncl.py
@@ -350,6 +350,11 @@ class StreamEpoch(namedtuple('StreamEpoch',
     def channel(self):
         return self.stream.channel
 
+    @property
+    def duration(self):
+        with none_as_max(self.endtime) as end:
+            return abs(end - self.starttime)
+
     def __eq__(self, other):
         """
         Allows comparing :py:class:`StreamEpoch` objects.
@@ -552,6 +557,11 @@ class StreamEpochs:
         Expose stream to provide an interface equal to StreamEpoch.
         """
         return self._stream
+
+    @property
+    def duration(self):
+        with none_as_max(self.endtime) as end:
+            return abs(end - self.starttime)
 
     def __iter__(self):
         """


### PR DESCRIPTION
**Features and Changes**:
- Allow configuration of limits for *ResponseTooLarge* (HTTP status code **413**) response. Implemented as specified within #113. Configuration is possible on `RequestProcessor` granularity.
- Currently, requests limits are only configured for `fdsnws-dataselect`.