### PR TITLE
Stationlite performance (application level)

### DIFF
--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -90,7 +90,7 @@ def find_streamepochs_and_routes(session, stream_epoch, service,
     Return routes for a given stream epoch.
 
     :param session: SQLAlchemy session
-    :type session: :py:class:`sqlalchemy.orm.sessionSession`
+    :type session: :py:class:`sqlalchemy.orm.session.Session`
     :param stream_epoch: StreamEpoch the database query is performed with
     :type stream_epoch: :py:class:`eidangservices.utils.sncl.StreamEpoch`
     :param str service: String specifying the webservice

--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -77,8 +77,7 @@ def resolve_vnetwork(session, stream_epoch, like_escape='/'):
             sliced_ses.append(se)
 
     logger.debug(
-        'Found {0!r} matching {0!r}'.format(sorted(sliced_ses),
-                                            stream_epoch))
+        'Found %r matching %r' % (sorted(sliced_ses), stream_epoch, ))
 
     return [se for ses in sliced_ses for se in ses]
 

--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -60,7 +60,7 @@ def resolve_vnetwork(session, stream_epoch, like_escape='/'):
         query = query.\
             filter(orm.StreamEpoch.starttime < sql_stream_epoch.endtime)
 
-    # slice the stream epoch
+    # slice stream epochs
     sliced_ses = []
     for s in query.all():
         # print('Query response: {0!r}'.format(StreamEpoch.from_orm(s)))

--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -21,8 +21,8 @@ def resolve_vnetwork(session, stream_epoch, like_escape='/'):
     """
     Resolve a stream epoch regarding virtual networks.
 
-    :returns: List of :py:class:`~eidangservices.utils.sncl.StreamEpochs` object
-        instances.
+    :returns: List of :py:class:`~eidangservices.utils.sncl.StreamEpochs`
+        object instances.
     :rtype: list
     """
     if (stream_epoch.network == settings.FDSNWS_QUERY_WILDCARD_MULT_CHAR or

--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -7,8 +7,8 @@ import collections
 import logging
 
 from eidangservices import utils, settings
-from eidangservices.utils.sncl import (StreamEpochs, StreamEpochsHandler,
-                                       none_as_max)
+from eidangservices.utils.sncl import (
+    StreamEpoch, StreamEpochs, StreamEpochsHandler, none_as_max)
 
 from eidangservices.stationlite.engine import orm
 
@@ -197,14 +197,15 @@ def find_streamepochs_and_routes(session, stream_epoch, service,
         # NOTE(damb): Set endtime to 'max' if undefined (i.e. device currently
         # acquiring data).
         with none_as_max(endtime) as end:
-            stream_epochs = StreamEpochs(
+            stream_epoch = StreamEpoch.from_sncl(
                 network=row[4],
                 station=sta,
                 location=loc,
                 channel=cha,
-                epochs=[(starttime, end)])
+                starttime=starttime,
+                endtime=end)
 
-            routes[row[8]].merge([stream_epochs])
+            routes[row[8]].add(stream_epoch)
 
     return [utils.Route(url=url, streams=streams)
             for url, streams in routes.items()]

--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -92,7 +92,7 @@ def find_streamepochs_and_routes(session, stream_epoch, service,
     :param session: SQLAlchemy session
     :type session: :py:class:`sqlalchemy.orm.session.Session`
     :param stream_epoch: StreamEpoch the database query is performed with
-    :type stream_epoch: :py:class:`eidangservices.utils.sncl.StreamEpoch`
+    :type stream_epoch: :py:class:`~eidangservices.utils.sncl.StreamEpoch`
     :param str service: String specifying the webservice
     :param str level: Optional `fdsnws-station` *level* parameter
     :param str access: Optional access parameter; The parameter is only taken
@@ -105,7 +105,7 @@ def find_streamepochs_and_routes(session, stream_epoch, service,
     :param float maxlon: Longitude smaller than or equal to the specified
         maximum
     :param str like_escape: Character used for the `SQL ESCAPE` statement
-    :return: List of :py:class:`eidangservices.utils.Route` objects
+    :return: List of :py:class:`~eidangservices.utils.Route` objects
     :rtype: list
     """
     VALID_ACCESS = ('open', 'closed', 'any')

--- a/eidangservices/stationlite/engine/dbquery.py
+++ b/eidangservices/stationlite/engine/dbquery.py
@@ -21,7 +21,7 @@ def resolve_vnetwork(session, stream_epoch, like_escape='/'):
     """
     Resolve a stream epoch regarding virtual networks.
 
-    :returns: List of :py:class:`eidangservices.utils.sncl.StreamEpoch` object
+    :returns: List of :py:class:`~eidangservices.utils.sncl.StreamEpochs` object
         instances.
     :rtype: list
     """

--- a/eidangservices/stationlite/server/routes/stationlite.py
+++ b/eidangservices/stationlite/server/routes/stationlite.py
@@ -97,7 +97,7 @@ class StationLiteResource(Resource):
 
     def _process_request(
             self, args, stream_epochs, netloc_proxy=None):
-        # resolve virtual network streamepochs
+        # resolve virtual network stream epochs
         vnet_stream_epochs = []
         for stream_epoch in stream_epochs:
             self.logger.debug(

--- a/eidangservices/stationlite/server/routes/stationlite.py
+++ b/eidangservices/stationlite/server/routes/stationlite.py
@@ -125,9 +125,7 @@ class StationLiteResource(Resource):
 
             routes.extend(_routes)
 
-        # flatten response list
         self.logger.debug('StationLite routes: %s' % routes)
-
         # merge stream epochs for each route
         merged_routes = collections.defaultdict(StreamEpochsHandler)
         for url, stream_epochs in routes:

--- a/eidangservices/stationlite/server/routes/stationlite.py
+++ b/eidangservices/stationlite/server/routes/stationlite.py
@@ -123,6 +123,12 @@ class StationLiteResource(Resource):
                 minlon=args['minlongitude'],
                 maxlon=args['maxlongitude'])
 
+            # adjust stream epochs regarding time constraints
+            for url, streams in _routes:
+                streams.modify_with_temporal_constraints(
+                    start=stream_epoch.starttime,
+                    end=stream_epoch.endtime)
+
             routes.extend(_routes)
 
         self.logger.debug('StationLite routes: %s' % routes)

--- a/eidangservices/stationlite/server/stream.py
+++ b/eidangservices/stationlite/server/stream.py
@@ -83,13 +83,13 @@ class GetStream(OutputStream):
                          GetStream.SERIALIZER.dump(stream_epoch).items()])
 
     def __str__(self):
-        retval = ''
+        lines = []
         for url, stream_epoch_lst in self.routes:
             # add url netloc prefix
             if self._netloc_proxy:
                 url = self.prefix_url(url)
 
-            for se in stream_epoch_lst:
-                retval += '{}?{}\n'.format(url, self._serialize(se))
+            lines.extend('{}?{}\n'.format(url, self._serialize(se))
+                         for se in stream_epoch_lst)
 
-        return retval
+        return ''.join(lines)

--- a/eidangservices/stationlite/server/stream.py
+++ b/eidangservices/stationlite/server/stream.py
@@ -53,21 +53,17 @@ class PostStream(OutputStream):
         return ' '.join(PostStream.SERIALIZER.dump(stream_epoch).values())
 
     def __str__(self):
-        retval = ''
+        lines = []
         for url, stream_epoch_lst in self.routes:
             # add url netloc prefix
             if self._netloc_proxy:
                 url = self.prefix_url(url)
 
-            if retval:
-                retval += '\n\n'
-            retval += url + '\n' + '\n'.join(self._serialize(se)
-                                             for se in stream_epoch_lst)
+            lines.append(url)
+            lines.extend('%s' % self._serialize(se) for se in stream_epoch_lst)
+            lines.append('')
 
-        if retval:
-            retval += '\n'
-
-        return retval
+        return '\n'.join(lines)
 
 
 class GetStream(OutputStream):

--- a/eidangservices/stationlite/server/stream.py
+++ b/eidangservices/stationlite/server/stream.py
@@ -45,12 +45,12 @@ class PostStream(OutputStream):
     """
     StationLite output stream for `format=post`.
     """
-    DESERIALIZER = eidangws.utils.schema.StreamEpochSchema(
+    SERIALIZER = eidangws.utils.schema.StreamEpochSchema(
         context={'routing': True})
 
     @staticmethod
-    def _deserialize(stream_epoch):
-        return ' '.join(PostStream.DESERIALIZER.dump(stream_epoch).values())
+    def _serialize(stream_epoch):
+        return ' '.join(PostStream.SERIALIZER.dump(stream_epoch).values())
 
     def __str__(self):
         retval = ''
@@ -61,7 +61,7 @@ class PostStream(OutputStream):
 
             if retval:
                 retval += '\n\n'
-            retval += url + '\n' + '\n'.join(self._deserialize(se)
+            retval += url + '\n' + '\n'.join(self._serialize(se)
                                              for se in stream_epoch_lst)
 
         if retval:
@@ -74,13 +74,13 @@ class GetStream(OutputStream):
     """
     StationLite output stream for `format=post`.
     """
-    DESERIALIZER = eidangws.utils.schema.StreamEpochSchema(
+    SERIALIZER = eidangws.utils.schema.StreamEpochSchema(
         context={'routing': True})
 
     @staticmethod
-    def _deserialize(stream_epoch):
+    def _serialize(stream_epoch):
         return '&'.join(['{}={}'.format(k, v) for k, v in
-                         GetStream.DESERIALIZER.dump(stream_epoch).items()])
+                         GetStream.SERIALIZER.dump(stream_epoch).items()])
 
     def __str__(self):
         retval = ''
@@ -90,6 +90,6 @@ class GetStream(OutputStream):
                 url = self.prefix_url(url)
 
             for se in stream_epoch_lst:
-                retval += '{}?{}\n'.format(url, self._deserialize(se))
+                retval += '{}?{}\n'.format(url, self._serialize(se))
 
         return retval

--- a/eidangservices/utils/fdsnws.py
+++ b/eidangservices/utils/fdsnws.py
@@ -63,12 +63,20 @@ class FDSNWSParserMixin:
         # preprocess the req.args multidict regarding SNCL parameters
         networks = _get_values(('net', 'network')) or ['*']
         networks = set(networks)
+        if '*' in networks:
+            networks = ['*']
         stations = _get_values(('sta', 'station')) or ['*']
         stations = set(stations)
+        if '*' in stations:
+            stations = ['*']
         locations = _get_values(('loc', 'location')) or ['*']
         locations = set(locations)
+        if '*' in locations:
+            locations = ['*']
         channels = _get_values(('cha', 'channel')) or ['*']
         channels = set(channels)
+        if '*' in channels:
+            channels= ['*']
 
         stream_epochs = []
         for prod in itertools.product(networks, stations, locations, channels):

--- a/eidangservices/utils/fdsnws.py
+++ b/eidangservices/utils/fdsnws.py
@@ -62,13 +62,13 @@ class FDSNWSParserMixin:
 
         # preprocess the req.args multidict regarding SNCL parameters
         networks = _get_values(('net', 'network')) or ['*']
-        networks = list(set(networks))
+        networks = set(networks)
         stations = _get_values(('sta', 'station')) or ['*']
-        stations = list(set(stations))
+        stations = set(stations)
         locations = _get_values(('loc', 'location')) or ['*']
-        locations = list(set(locations))
+        locations = set(locations)
         channels = _get_values(('cha', 'channel')) or ['*']
-        channels = list(set(channels))
+        channels = set(channels)
 
         stream_epochs = []
         for prod in itertools.product(networks, stations, locations, channels):

--- a/eidangservices/utils/sncl.py
+++ b/eidangservices/utils/sncl.py
@@ -314,7 +314,7 @@ class StreamEpoch(namedtuple('StreamEpoch',
         """
         if num < 2:
             return [self]
-        end = self.endtime if self.endtime else default_endtime
+        end = self.endtime or default_endtime
         t = Epochs.from_tuples([(self.starttime, end)])
 
         for n in range(1, num):

--- a/eidangservices/utils/tests/fdsnws.py
+++ b/eidangservices/utils/tests/fdsnws.py
@@ -69,6 +69,54 @@ class FDSNWSParserMixinTestCase(unittest.TestCase):
         self.assertIn(test_dict['stream_epochs'][0], reference_result)
         self.assertIn(test_dict['stream_epochs'][1], reference_result)
 
+    def test_parse_dict_multiple_redundant(self):
+        arg_dict = MultiDict({'f': 'value',
+                              'net': 'CH',
+                              'sta': 'DAVOX,BALST,BALST,BALST',
+                              'start': '2017-01-01',
+                              'end': '2017-01-07'})
+
+        reference_result = [{
+            'net': 'CH',
+            'sta': 'DAVOX',
+            'loc': '*',
+            'cha': '*',
+            'start': '2017-01-01',
+            'end': '2017-01-07'}, {
+            'net': 'CH',
+            'sta': 'BALST',
+            'loc': '*',
+            'cha': '*',
+            'start': '2017-01-01',
+            'end': '2017-01-07'}]
+
+        test_dict = fdsnws.FDSNWSParserMixin.\
+            _parse_streamepochs_from_argdict(arg_dict)
+
+        self.assertEqual(len(test_dict['stream_epochs']), 2)
+        self.assertIn(test_dict['stream_epochs'][0], reference_result)
+        self.assertIn(test_dict['stream_epochs'][1], reference_result)
+
+    def test_parse_dict_multiple_star(self):
+        arg_dict = MultiDict({'f': 'value',
+                              'net': 'CH',
+                              'sta': 'DAVOX,BALST,*',
+                              'start': '2017-01-01',
+                              'end': '2017-01-07'})
+
+        reference_result = [{
+            'net': 'CH',
+            'sta': '*',
+            'loc': '*',
+            'cha': '*',
+            'start': '2017-01-01',
+            'end': '2017-01-07'}, ]
+
+        test_dict = fdsnws.FDSNWSParserMixin.\
+            _parse_streamepochs_from_argdict(arg_dict)
+
+        self.assertEqual(test_dict['stream_epochs'], reference_result)
+
     def test_postfile_single(self):
         postfile = "f=value\nNL HGN ?? * 2013-10-10 2013-10-11"
 

--- a/eidangservices/utils/tests/fdsnws.py
+++ b/eidangservices/utils/tests/fdsnws.py
@@ -65,6 +65,7 @@ class FDSNWSParserMixinTestCase(unittest.TestCase):
         test_dict = fdsnws.FDSNWSParserMixin.\
             _parse_streamepochs_from_argdict(arg_dict)
 
+        self.assertEqual(len(test_dict['stream_epochs']), 2)
         self.assertIn(test_dict['stream_epochs'][0], reference_result)
         self.assertIn(test_dict['stream_epochs'][1], reference_result)
 

--- a/eidangservices/utils/tests/fdsnws.py
+++ b/eidangservices/utils/tests/fdsnws.py
@@ -65,7 +65,8 @@ class FDSNWSParserMixinTestCase(unittest.TestCase):
         test_dict = fdsnws.FDSNWSParserMixin.\
             _parse_streamepochs_from_argdict(arg_dict)
 
-        self.assertEqual(test_dict['stream_epochs'], reference_result)
+        self.assertIn(test_dict['stream_epochs'][0], reference_result)
+        self.assertIn(test_dict['stream_epochs'][1], reference_result)
 
     def test_postfile_single(self):
         postfile = "f=value\nNL HGN ?? * 2013-10-10 2013-10-11"
@@ -109,7 +110,12 @@ class FDSNWSParserMixinTestCase(unittest.TestCase):
         test_dict = fdsnws.FDSNWSParserMixin.\
             _parse_postfile(postfile)
 
-        self.assertEqual(test_dict, reference_result)
+        self.assertIn('f', test_dict)
+        self.assertEqual(test_dict['f'], reference_result['f'])
+        self.assertIn(test_dict['stream_epochs'][1],
+                      reference_result['stream_epochs'])
+        self.assertIn(test_dict['stream_epochs'][0],
+                      reference_result['stream_epochs'])
 
     def test_postfile_invalid(self):
         postfile = "f=value\nNL HGN * 2013-10-10 2013-10-11"
@@ -232,7 +238,7 @@ class FDSNWSFlaskParserTestCase(unittest.TestCase):
             context={'request': mock_request}),
             mock_request,
             locations=('query',))['stream_epochs']
-        self.assertEqual(sncls, reference_sncls)
+        self.assertEqual(sorted(sncls), sorted(reference_sncls))
 
     @mock.patch('flask.Request')
     def test_get_missing(self, mock_request):
@@ -316,11 +322,13 @@ class FDSNWSFlaskParserTestCase(unittest.TestCase):
         test_args = fdsnws.fdsnws_parser.parse(self.TestSchema(), mock_request,
                                                locations=('form',))
         self.assertEqual(dict(test_args), {'f': 'value'})
+
         sncls = fdsnws.fdsnws_parser.parse(schema.ManyStreamEpochSchema(
             context={'request': mock_request}),
             mock_request,
             locations=('form',))['stream_epochs']
-        self.assertEqual(sncls, reference_sncls)
+        self.assertIn(sncls[0], reference_sncls)
+        self.assertIn(sncls[1], reference_sncls)
 
     @mock.patch('flask.Request')
     def test_post_empty(self, mock_request):


### PR DESCRIPTION
**Features and Changes**:
- Improve `eida-stationlite` performance at application level. Implement a more efficient post processing. Stats follow.

**Bugfixes**:
- Remove duplicate stream epochs when parsing query arguments.


Note, that this PR does not come along with DB related performance improvements. DB related performance improvements will be provided within a separate PR.